### PR TITLE
fix(bitbucket): make project key and repo slug case-insensitive

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -2086,4 +2086,78 @@ describe('BitbucketService', () => {
       expect(result.error).toBe('Not Found');
     });
   });
+
+  describe('case-insensitive project keys and repository slugs', () => {
+    it('should uppercase projectKey and lowercase repositorySlug for getPullRequests', async () => {
+      const mockData = { values: [], size: 0, isLastPage: true };
+      (PullRequestsService.getPage as jest.Mock).mockResolvedValue(mockData);
+
+      await bitbucketService.getPullRequests('test', 'Test-Repo');
+
+      expect(PullRequestsService.getPage).toHaveBeenCalledWith(
+        'TEST',
+        'test-repo',
+        undefined, undefined, undefined, undefined, undefined,
+        undefined, undefined, undefined, undefined, 25
+      );
+    });
+
+    it('should uppercase projectKey and lowercase repositorySlug for getPullRequest', async () => {
+      const mockData = { id: 1, title: 'Test PR' };
+      (PullRequestsService.get3 as jest.Mock).mockResolvedValue(mockData);
+
+      await bitbucketService.getPullRequest('test', 'Test-Repo', '1');
+
+      expect(PullRequestsService.get3).toHaveBeenCalledWith('TEST', '1', 'test-repo');
+    });
+
+    it('should uppercase projectKey and lowercase repositorySlug for getPullRequestChanges', async () => {
+      const mockData = { values: [], size: 0, isLastPage: true };
+      (PullRequestsService.streamChanges1 as jest.Mock).mockResolvedValue(mockData);
+
+      await bitbucketService.getPullRequestChanges('test', 'Test-Repo', '1');
+
+      expect(PullRequestsService.streamChanges1).toHaveBeenCalledWith(
+        'TEST', '1', 'test-repo',
+        undefined, undefined, undefined, undefined, undefined, 25
+      );
+    });
+
+    it('should uppercase projectKey and lowercase repositorySlug for createPullRequest', async () => {
+      const mockData = { id: 1, title: 'New PR' };
+      (PullRequestsService.create as jest.Mock).mockResolvedValue(mockData);
+
+      await bitbucketService.createPullRequest(
+        'test', 'Test-Repo', 'title', 'desc',
+        'refs/heads/feature', 'refs/heads/main'
+      );
+
+      expect(PullRequestsService.create).toHaveBeenCalledWith(
+        'TEST', 'test-repo',
+        expect.objectContaining({
+          title: 'title',
+          fromRef: expect.objectContaining({
+            repository: expect.objectContaining({
+              slug: 'test-repo',
+              project: { key: 'TEST' }
+            })
+          })
+        })
+      );
+    });
+
+    it('should uppercase projectKey and lowercase repositorySlug for getRequiredReviewers', async () => {
+      const mockData: never[] = [];
+      (PullRequestsService.getReviewers as jest.Mock).mockResolvedValue(mockData);
+
+      await bitbucketService.getRequiredReviewers(
+        'test', 'Test-Repo', 'refs/heads/feature', 'refs/heads/main'
+      );
+
+      expect(PullRequestsService.getReviewers).toHaveBeenCalledWith(
+        'TEST', 'test-repo', undefined, undefined,
+        'refs/heads/feature', 'refs/heads/main'
+      );
+    });
+  });
 });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -58,6 +58,8 @@ export class BitbucketService {
   async getCommits(projectKey: string, repositorySlug: string, path?: string, since?: string, until?: string,
     limit?: number
   ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
     return handleApiOperation(
       () => RepositoryService.getCommits(
         projectKey,
@@ -99,6 +101,7 @@ export class BitbucketService {
    * @returns Promise with project data
    */
   async getProject(projectKey: string) {
+    projectKey = projectKey.toUpperCase();
     return handleApiOperation(
       () => ProjectService.getProject(projectKey),
       'Error fetching project'
@@ -113,6 +116,7 @@ export class BitbucketService {
    * @returns Promise with repositories data
    */
   async getRepositories(projectKey: string, start?: number, limit?: number) {
+    projectKey = projectKey.toUpperCase();
     return handleApiOperation(
       () => ProjectService.getRepositories(projectKey, start, limit ?? this.getPageSize()),
       'Error fetching repositories'
@@ -126,6 +130,8 @@ export class BitbucketService {
    * @returns Promise with repository data
    */
   async getRepository(projectKey: string, repositorySlug: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
     return handleApiOperation(
       () => ProjectService.getRepository(projectKey, repositorySlug),
       'Error fetching repository'
@@ -162,6 +168,8 @@ export class BitbucketService {
     start?: number,
     limit?: number
   ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
     return handleApiOperation(
       () => PullRequestsService.getPage(
         projectKey,
@@ -193,6 +201,8 @@ export class BitbucketService {
     repositorySlug: string,
     pullRequestId: string
   ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
     return handleApiOperation(
       () => PullRequestsService.get3(projectKey, pullRequestId, repositorySlug),
       'Error fetching pull request'
@@ -208,6 +218,8 @@ export class BitbucketService {
     output: BitbucketOutputMode = 'compact',
     includeResolved = false
   ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
     const result = await handleApiOperation(
       () => PullRequestsService.getActivities(
         projectKey,
@@ -256,6 +268,8 @@ export class BitbucketService {
     limit?: number,
     output: BitbucketOutputMode = 'compact'
   ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
     const result = await handleApiOperation(
       () => PullRequestsService.streamChanges1(
         projectKey,
@@ -308,6 +322,8 @@ export class BitbucketService {
     pending?: boolean,
     output: BitbucketMutationOutputMode = 'ack'
   ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
     const comment: any = {
       text
     };
@@ -404,6 +420,8 @@ export class BitbucketService {
     status: 'APPROVED' | 'NEEDS_WORK' | 'UNAPPROVED',
     lastReviewedCommit?: string
   ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
     const requestBody: any = {
       status,
       ...(lastReviewedCommit ? { lastReviewedCommit } : {})
@@ -448,6 +466,8 @@ export class BitbucketService {
     untilId?: string,
     whitespace?: string
   ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
     return handleApiOperation(
       () => __request(OpenAPI, {
         method: 'GET',
@@ -500,6 +520,8 @@ export class BitbucketService {
     reviewers?: string[],
     output: BitbucketMutationOutputMode = 'ack'
   ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
     const pullRequestData: any = {
       title,
       description,
@@ -567,6 +589,8 @@ export class BitbucketService {
     reviewers?: string[],
     output: BitbucketMutationOutputMode = 'ack'
   ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
     const pullRequestData: any = {
       version
     };
@@ -622,6 +646,8 @@ export class BitbucketService {
     sourceRepoId?: string,
     targetRepoId?: string
   ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
     return handleApiOperation(
       () => PullRequestsService.getReviewers(
         projectKey,


### PR DESCRIPTION
## Summary
- Normalize projectKey to uppercase and repositorySlug to lowercase at the BitbucketService layer entry points
- Fixes failures when project keys are extracted from git remote URLs (which are lowercase) and passed directly to MCP tools
- Adds 5 tests verifying case normalization across key service methods

## Test plan
- [x] All 126 existing bitbucket tests pass
- [x] New tests verify lowercase projectKey is uppercased and mixed-case repositorySlug is lowercased before API calls