### PR TITLE
feat(bitbucket): improve updatePullRequest tool descriptions for version parameter

### DIFF
--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -853,7 +853,7 @@ export const bitbucketToolSchemas = {
     projectKey: z.string().describe("The project key"),
     repositorySlug: z.string().describe("The repository slug"),
     pullRequestId: z.string().describe("The pull request ID"),
-    version: z.number().describe("The current version of the pull request (required for optimistic locking)"),
+    version: z.number().describe("The current version of the pull request (required for optimistic locking). Obtain this by calling bitbucket_getPullRequest first."),
     title: z.string().optional().describe("The new title for the pull request"),
     description: z.string().optional().describe("The new description for the pull request"),
     reviewers: z.array(z.string()).optional().describe("Optional array of reviewer usernames to set"),

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -89,7 +89,7 @@ server.tool(
 
 server.tool(
   "bitbucket_getPullRequest",
-  "Get a specific pull request by ID. Returns full details including title, description, reviewers, participants, author, source/target branches, and current state.",
+  "Get a specific pull request by ID. Returns full details including title, description, reviewers, participants, author, source/target branches, current state, and version (needed for bitbucket_updatePullRequest).",
   bitbucketToolSchemas.getPullRequest,
   async ({ projectKey, repositorySlug, pullRequestId }) => {
     const result = await bitbucketService.getPullRequest(projectKey, repositorySlug, pullRequestId);
@@ -170,7 +170,7 @@ server.tool(
 
 server.tool(
   "bitbucket_updatePullRequest",
-  "Update the title, description, reviewers, destination branch or draft status of an existing pull request. IMPORTANT: The reviewers parameter replaces ALL existing reviewers. If you want to preserve existing reviewers, first fetch the current PR details (using bitbucket_getPullRequests filtered by ID) and include those reviewers along with any new ones you want to add.",
+  "Update the title, description, reviewers, destination branch or draft status of an existing pull request. IMPORTANT: You MUST first call bitbucket_getPullRequest to get the current 'version' number — this is required for optimistic locking and the call will fail without it. The reviewers parameter replaces ALL existing reviewers. If you want to preserve existing reviewers, include those from the current PR details along with any new ones you want to add.",
   bitbucketToolSchemas.updatePullRequest,
   async ({ projectKey, repositorySlug, pullRequestId, version, title, description, reviewers, output }) => {
     const result = await bitbucketService.updatePullRequest(projectKey, repositorySlug, pullRequestId, version, title, description, reviewers, output);


### PR DESCRIPTION
### Summary
- Add explicit guidance that callers must first fetch the PR via `bitbucket_getPullRequest` to obtain the required `version` parameter before calling `updatePullRequest`
- Update `getPullRequest` description to mention it returns `version` needed for updates
- Improve `version` parameter description to direct callers to the correct source

---
🤖 PR generated by AI