### PR TITLE
fix(jira): make description optional in jira_createIssue

### DIFF
--- a/packages/jira/src/jira-service.ts
+++ b/packages/jira/src/jira-service.ts
@@ -77,17 +77,20 @@ export class JiraService {
   async createIssue(params: {
     projectId: string;
     summary: string;
-    description: string;
+    description?: string;
     issueTypeId: string;
     customFields?: Record<string, any>;
   }) {
     return handleApiOperation(async () => {
-      const standardFields = {
+      const standardFields: Record<string, any> = {
         project: { key: params.projectId },
         summary: params.summary,
-        description: params.description,
         issuetype: { id: params.issueTypeId }
       };
+
+      if (params.description !== undefined && params.description !== '') {
+        standardFields.description = params.description;
+      }
 
       const fields = params.customFields
         ? { ...standardFields, ...params.customFields }
@@ -178,7 +181,7 @@ export const jiraToolSchemas = {
   createIssue: {
     projectId: z.string().describe("Project key (despite the parameter name, e.g. TEST)"),
     summary: z.string().describe("Issue summary"),
-    description: z.string().describe("Issue description in the format suitable for JIRA DATA CENTER edition (JIRA Wiki Markup)."),
+    description: z.string().optional().describe("Issue description in the format suitable for JIRA DATA CENTER edition (JIRA Wiki Markup). Optional — omit if the project's create screen does not include the description field, and use customFields to pass a project-specific description custom field instead."),
     issueTypeId: z.string().describe("Issue type id (e.g. id of Task, Bug, Story). Should be found first a correct number for specific JIRA installation."),
     customFields: z.record(z.any()).optional().describe("Optional fields merged into the JIRA create payload. Can be used for custom fields and standard fields such as labels. Examples: {'customfield_10001': 'Custom Value', 'priority': {'id': '1'}, 'assignee': {'name': 'john.doe'}, 'labels': ['urgent', 'bug']}")
   },


### PR DESCRIPTION
Some Jira project create screens do not include the standard description field (they use a custom field instead, or simply omit it). Previously, jira_createIssue always sent `description` in the payload, causing a 400 error: "Field 'description' cannot be set. It is not on the appropriate screen, or unknown."

description is now optional in both the method signature and the Zod schema. When omitted or empty, it is not included in the API payload, allowing creation to succeed. The description field note instructs users to pass project-specific description custom fields via customFields.