### PR TITLE
feat(setup): add CLI flags and non-interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,33 @@ npx @atlassian-dc-mcp/bitbucket setup
 
 The setup CLI prompts for host, API base path, default page size, and API token. Before saving, it validates obvious input mistakes and performs a timed authenticated request to the selected Atlassian product, so a bad host, base path, or token is caught during setup.
 
+### CLI flags and non-interactive mode
+
+Setup accepts flags so you can prefill values or skip prompts entirely (useful for scripted bootstrap, CI, or remote sessions). Run `npx @atlassian-dc-mcp/<product> setup --help` for the full list.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--host <value>` | `-H` | Host, e.g. `jira.example.com` |
+| `--api-base-path <value>` | `-b` | API base path or full URL |
+| `--token <value>` | `-t` | API token |
+| `--default-page-size <n>` | `-s` | Default page size (positive integer) |
+| `--non-interactive` | `-n` | Skip prompts; fail if a required value cannot be resolved |
+| `--help` | `-h` | Show usage and exit |
+
+In interactive mode, any flag you pass prefills its prompt (so e.g. `--host` skips the host prompt but still asks for the rest). In `--non-interactive` mode, setup resolves anything missing from existing configuration (process env, `~/.atlassian-dc-mcp/<product>.env`, or macOS Keychain) and exits non-zero if a host (or full-URL `--api-base-path`) and token cannot be found. An existing token is reused when `--token` is omitted.
+
+```bash
+# Scripted, no prompts, write everything from flags
+npx @atlassian-dc-mcp/jira setup --non-interactive \
+  --host jira.example.com \
+  --token "$JIRA_TOKEN"
+
+# Re-validate the existing token without re-entering it
+npx @atlassian-dc-mcp/jira setup --non-interactive --host jira.example.com
+```
+
+Credential validation behaves differently between modes: interactive mode offers retry/save-anyway prompts on failure, while `--non-interactive` exits with code 1 on the first validation failure so it can be used as a CI gate.
+
 Token storage:
 
 - **macOS** — written to the login Keychain via `/usr/bin/security` (service `atlassian-dc-mcp`, account `<product>-token`).

--- a/packages/bitbucket/README.md
+++ b/packages/bitbucket/README.md
@@ -31,6 +31,18 @@ After setup, you can launch the server without any environment variables:
 
 Environment variables still override stored values — see [Configuration sources](#configuration-sources) below.
 
+### Scripted / non-interactive setup
+
+For CI, remote sessions, or shell scripts, pass values as flags and add `--non-interactive` to skip prompts:
+
+```bash
+npx @atlassian-dc-mcp/bitbucket setup --non-interactive \
+  --host bitbucket.example.com \
+  --token "$BITBUCKET_TOKEN"
+```
+
+Available flags: `--host`/`-H`, `--api-base-path`/`-b`, `--token`/`-t`, `--default-page-size`/`-s`, `--non-interactive`/`-n`, `--help`/`-h`. In `--non-interactive` mode, missing values fall back to existing configuration and the run exits non-zero if a host (or full-URL `--api-base-path`) and token cannot be resolved. An existing token is reused when `--token` is omitted. Run `npx @atlassian-dc-mcp/bitbucket setup --help` for full usage.
+
 ## Claude Desktop Configuration
 
 To use this MCP connector with Claude Desktop, add the following to your Claude Desktop configuration:

--- a/packages/bitbucket/src/setup.ts
+++ b/packages/bitbucket/src/setup.ts
@@ -1,8 +1,8 @@
-import { describeValidationError, runSetup } from '@atlassian-dc-mcp/common';
+import { describeValidationError, runSetupCli } from '@atlassian-dc-mcp/common';
 import { BITBUCKET_PRODUCT } from './config.js';
 import { BitbucketService } from './bitbucket-service.js';
 
-await runSetup(BITBUCKET_PRODUCT, {
+await runSetupCli(BITBUCKET_PRODUCT, {
   validateCredentials: async ({ host, apiBasePath, token }) => {
     const service = new BitbucketService(host || undefined, token, apiBasePath || undefined);
     try {

--- a/packages/common/src/__tests__/args.test.ts
+++ b/packages/common/src/__tests__/args.test.ts
@@ -1,0 +1,132 @@
+import { parseSetupArgs, printSetupHelp, SetupArgsError } from '../setup/args.js';
+
+describe('parseSetupArgs', () => {
+  it('returns defaults for an empty argv', () => {
+    const args = parseSetupArgs([]);
+    expect(args).toEqual({
+      host: undefined,
+      apiBasePath: undefined,
+      token: undefined,
+      defaultPageSize: undefined,
+      nonInteractive: false,
+      help: false,
+    });
+  });
+
+  it('parses every supported flag with = form and space form', () => {
+    const args = parseSetupArgs([
+      '--host=jira.example.com',
+      '--api-base-path',
+      '/rest/api/2',
+      '--token=secret',
+      '--default-page-size=50',
+      '--non-interactive',
+    ]);
+    expect(args).toEqual({
+      host: 'jira.example.com',
+      apiBasePath: '/rest/api/2',
+      token: 'secret',
+      defaultPageSize: '50',
+      nonInteractive: true,
+      help: false,
+    });
+  });
+
+  it('treats whitespace-only and empty values as not provided', () => {
+    const args = parseSetupArgs(['--host=', '--token=   ']);
+    expect(args.host).toBeUndefined();
+    expect(args.token).toBeUndefined();
+  });
+
+  it('supports -h as short alias for --help', () => {
+    expect(parseSetupArgs(['-h']).help).toBe(true);
+    expect(parseSetupArgs(['--help']).help).toBe(true);
+  });
+
+  it('supports short aliases for every flag', () => {
+    const args = parseSetupArgs([
+      '-H', 'jira.example.com',
+      '-b', '/rest/api/2',
+      '-t', 'short-token',
+      '-s', '50',
+      '-n',
+    ]);
+    expect(args).toEqual({
+      host: 'jira.example.com',
+      apiBasePath: '/rest/api/2',
+      token: 'short-token',
+      defaultPageSize: '50',
+      nonInteractive: true,
+      help: false,
+    });
+  });
+
+  describe('short alias mapping', () => {
+    it('-H sets host', () => {
+      expect(parseSetupArgs(['-H', 'jira.example.com']).host).toBe('jira.example.com');
+    });
+
+    it('-b sets api-base-path', () => {
+      expect(parseSetupArgs(['-b', '/rest/api/2']).apiBasePath).toBe('/rest/api/2');
+    });
+
+    it('-t sets token', () => {
+      expect(parseSetupArgs(['-t', 'secret']).token).toBe('secret');
+    });
+
+    it('-s sets default-page-size', () => {
+      expect(parseSetupArgs(['-s', '100']).defaultPageSize).toBe('100');
+    });
+
+    it('-n sets non-interactive', () => {
+      expect(parseSetupArgs(['-n']).nonInteractive).toBe(true);
+    });
+
+    it('short and long forms produce identical output', () => {
+      const short = parseSetupArgs([
+        '-H', 'jira.example.com',
+        '-b', '/rest',
+        '-t', 'tok',
+        '-s', '25',
+        '-n',
+      ]);
+      const long = parseSetupArgs([
+        '--host', 'jira.example.com',
+        '--api-base-path', '/rest',
+        '--token', 'tok',
+        '--default-page-size', '25',
+        '--non-interactive',
+      ]);
+      expect(short).toEqual(long);
+    });
+
+    it('-H is not aliased to help (lowercase -h is help, uppercase -H is host)', () => {
+      expect(parseSetupArgs(['-H', 'jira.example.com']).help).toBe(false);
+      expect(parseSetupArgs(['-h']).help).toBe(true);
+      expect(parseSetupArgs(['-h']).host).toBeUndefined();
+    });
+
+    it('rejects unknown single-letter flags', () => {
+      expect(() => parseSetupArgs(['-x'])).toThrow(SetupArgsError);
+    });
+  });
+
+  it('throws SetupArgsError on an unknown flag', () => {
+    expect(() => parseSetupArgs(['--unknown'])).toThrow(SetupArgsError);
+  });
+
+  it('throws SetupArgsError on a stray positional', () => {
+    expect(() => parseSetupArgs(['extra'])).toThrow(SetupArgsError);
+  });
+});
+
+describe('printSetupHelp', () => {
+  it('emits product-aware lines including the home file path', () => {
+    const out: string[] = [];
+    printSetupHelp('jira', (m) => out.push(m));
+    const joined = out.join('\n');
+    expect(joined).toContain('@atlassian-dc-mcp/jira setup');
+    expect(joined).toContain('--non-interactive');
+    expect(joined).toContain('~/.atlassian-dc-mcp/jira.env');
+  });
+});

--- a/packages/common/src/__tests__/setup-cli.test.ts
+++ b/packages/common/src/__tests__/setup-cli.test.ts
@@ -9,7 +9,20 @@ import {
   type SetupPrompts,
   type ValidateCredentials,
 } from '../setup-cli.js';
+import type { ParsedSetupArgs } from '../setup/args.js';
 import type { ConfigKey, ProductDefinition } from '../config/source.js';
+
+function makeArgs(overrides: Partial<ParsedSetupArgs> = {}): ParsedSetupArgs {
+  return {
+    host: undefined,
+    apiBasePath: undefined,
+    token: undefined,
+    defaultPageSize: undefined,
+    nonInteractive: false,
+    help: false,
+    ...overrides,
+  };
+}
 
 const JIRA: ProductDefinition = {
   id: 'jira',
@@ -314,5 +327,204 @@ describe('runSetup', () => {
     expect(exitFn).toHaveBeenCalledWith(130);
     expect(keychain.writeCalls).toBe(0);
     expect(home.writes).toHaveLength(0);
+  });
+
+  it('skips the host prompt when --host is passed and still prompts for the rest', async () => {
+    const inputCalls: string[] = [];
+    const passwordCalls = jest.fn(async () => 'secret');
+    const registry = makeRegistry(keychain, home);
+
+    await runSetup(JIRA, {
+      registry,
+      log: (m) => logs.push(m),
+      exit: () => undefined,
+      args: makeArgs({ host: 'cli-host.example.com' }),
+      prompts: {
+        input: async (opts) => {
+          inputCalls.push(opts.message);
+          if (opts.message.startsWith('API base path')) return '/rest/api/2';
+          return '25';
+        },
+        password: passwordCalls,
+        confirm: async (opts) => opts.default ?? false,
+      },
+    });
+
+    expect(inputCalls.some((m) => m.startsWith('Host'))).toBe(false);
+    expect(inputCalls.some((m) => m.startsWith('API base path'))).toBe(true);
+    expect(passwordCalls).toHaveBeenCalledTimes(1);
+    expect(home.values.jira.host).toBe('cli-host.example.com');
+  });
+
+  describe('non-interactive mode', () => {
+    function nonInteractivePrompts(): SetupPrompts & { inputCalls: string[]; passwordCalls: number } {
+      const inputCalls: string[] = [];
+      let passwordCalls = 0;
+      return Object.assign(
+        {
+          input: async (opts: { message: string }) => {
+            inputCalls.push(opts.message);
+            return '';
+          },
+          password: async () => {
+            passwordCalls++;
+            return '';
+          },
+          confirm: async () => false,
+        },
+        {
+          inputCalls,
+          get passwordCalls() {
+            return passwordCalls;
+          },
+        },
+      ) as SetupPrompts & { inputCalls: string[]; passwordCalls: number };
+    }
+
+    it('writes everything without prompts when all required fields come from CLI args', async () => {
+      const validator = new StubCredentialValidator();
+      const exitFn = jest.fn();
+      const registry = makeRegistry(keychain, home);
+      const prompts = nonInteractivePrompts();
+
+      await runSetup(JIRA, {
+        registry,
+        log: (m) => logs.push(m),
+        exit: exitFn,
+        prompts,
+        validateCredentials: validator.asFn(),
+        args: makeArgs({
+          host: 'cli-host.example.com',
+          token: 'cli-token',
+          nonInteractive: true,
+        }),
+      });
+
+      expect(prompts.inputCalls).toHaveLength(0);
+      expect(prompts.passwordCalls).toBe(0);
+      expect(exitFn).not.toHaveBeenCalled();
+      expect(validator.calls).toEqual([
+        { host: 'cli-host.example.com', apiBasePath: '/rest/api/2', token: 'cli-token' },
+      ]);
+      expect(home.values.jira.host).toBe('cli-host.example.com');
+      expect(home.values.jira.apiBasePath).toBe('/rest/api/2');
+      expect(keychain.store).toBe('cli-token');
+    });
+
+    it('exits 1 when --token is missing and there is no existing token', async () => {
+      const validator = new StubCredentialValidator();
+      const exitFn = jest.fn();
+      const registry = makeRegistry(keychain, home);
+
+      await runSetup(JIRA, {
+        registry,
+        log: (m) => logs.push(m),
+        exit: exitFn,
+        prompts: nonInteractivePrompts(),
+        validateCredentials: validator.asFn(),
+        args: makeArgs({ host: 'cli-host.example.com', nonInteractive: true }),
+      });
+
+      expect(exitFn).toHaveBeenCalledWith(1);
+      expect(validator.calls).toHaveLength(0);
+      expect(keychain.writeCalls).toBe(0);
+      expect(home.writes).toHaveLength(0);
+      expect(logs.some((l) => l.includes('JIRA_API_TOKEN'))).toBe(true);
+    });
+
+    it('reuses an existing keychain token without rewriting it when --token is omitted', async () => {
+      keychain.store = 'kept-token';
+      const validator = new StubCredentialValidator();
+      const exitFn = jest.fn();
+      const registry = makeRegistry(keychain, home);
+
+      await runSetup(JIRA, {
+        registry,
+        log: (m) => logs.push(m),
+        exit: exitFn,
+        prompts: nonInteractivePrompts(),
+        validateCredentials: validator.asFn(),
+        args: makeArgs({ host: 'cli-host.example.com', nonInteractive: true }),
+      });
+
+      expect(exitFn).not.toHaveBeenCalled();
+      expect(validator.calls).toEqual([
+        { host: 'cli-host.example.com', apiBasePath: '/rest/api/2', token: 'kept-token' },
+      ]);
+      expect(keychain.writeCalls).toBe(0);
+      expect(keychain.store).toBe('kept-token');
+      const tokenWrites = home.writes.filter(([, k]) => k === 'token');
+      expect(tokenWrites).toHaveLength(0);
+    });
+
+    it('exits 1 with a format error when --default-page-size is not a positive integer', async () => {
+      const exitFn = jest.fn();
+      const registry = makeRegistry(keychain, home);
+
+      await runSetup(JIRA, {
+        registry,
+        log: (m) => logs.push(m),
+        exit: exitFn,
+        prompts: nonInteractivePrompts(),
+        args: makeArgs({
+          host: 'cli-host.example.com',
+          token: 'cli-token',
+          defaultPageSize: 'abc',
+          nonInteractive: true,
+        }),
+      });
+
+      expect(exitFn).toHaveBeenCalledWith(1);
+      expect(home.writes).toHaveLength(0);
+      expect(keychain.writeCalls).toBe(0);
+      expect(logs.some((l) => l.includes('default page size'))).toBe(true);
+    });
+
+    it('exits 1 on credential rejection without retrying or asking to save anyway', async () => {
+      const validator = new StubCredentialValidator().reject('401 Unauthorized');
+      const exitFn = jest.fn();
+      const confirmFn = jest.fn(async () => false);
+      const registry = makeRegistry(keychain, home);
+
+      await runSetup(JIRA, {
+        registry,
+        log: (m) => logs.push(m),
+        exit: exitFn,
+        prompts: { ...nonInteractivePrompts(), confirm: confirmFn },
+        validateCredentials: validator.asFn(),
+        args: makeArgs({
+          host: 'cli-host.example.com',
+          token: 'cli-token',
+          nonInteractive: true,
+        }),
+      });
+
+      expect(validator.calls).toHaveLength(1);
+      expect(exitFn).toHaveBeenCalledWith(1);
+      expect(confirmFn).not.toHaveBeenCalled();
+      expect(keychain.writeCalls).toBe(0);
+      expect(home.writes).toHaveLength(0);
+    });
+
+    it('falls back to product.defaultApiBasePath and FALLBACK_PAGE_SIZE for unspecified optional fields', async () => {
+      const validator = new StubCredentialValidator();
+      const registry = makeRegistry(keychain, home);
+
+      await runSetup(JIRA, {
+        registry,
+        log: (m) => logs.push(m),
+        exit: () => undefined,
+        prompts: nonInteractivePrompts(),
+        validateCredentials: validator.asFn(),
+        args: makeArgs({
+          host: 'cli-host.example.com',
+          token: 'cli-token',
+          nonInteractive: true,
+        }),
+      });
+
+      expect(home.values.jira.apiBasePath).toBe('/rest/api/2');
+      expect(home.values.jira.defaultPageSize).toBe('25');
+    });
   });
 });

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,8 +3,9 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 export * from './api-error-handler.js'
 export * from './config/index.js';
-export { runSetup } from './setup-cli.js';
+export { runSetup, runSetupCli } from './setup-cli.js';
 export { describeValidationError } from './setup/describe-error.js';
+export { parseSetupArgs, printSetupHelp, SetupArgsError, type ParsedSetupArgs } from './setup/args.js';
 
 // Helper function to format tool responses
 export const formatToolResponse = (result: unknown) => ({

--- a/packages/common/src/setup-cli.ts
+++ b/packages/common/src/setup-cli.ts
@@ -1,6 +1,6 @@
 import { confirm as inquirerConfirm, input as inquirerInput, password as inquirerPassword } from '@inquirer/prompts';
 import { buildDefaultRegistry, type ConfigRegistry } from './config/registry.js';
-import { getProductRuntimeConfig } from './config/runtime-config.js';
+import type { ProductRuntimeConfig } from './config/runtime-config.js';
 import type {
   ConfigKey,
   ProductDefinition,
@@ -8,6 +8,7 @@ import type {
 } from './config/source.js';
 import { HomeFileSource, getHomeFilePath } from './config/sources/home-file.js';
 import { MacosKeychainSource } from './config/sources/macos-keychain.js';
+import { parseSetupArgs, printSetupHelp, SetupArgsError, type ParsedSetupArgs } from './setup/args.js';
 import { SetupValueValidator } from './setup/value-validator.js';
 
 const FALLBACK_PAGE_SIZE = 25;
@@ -56,6 +57,7 @@ export type SetupDeps = {
   exit?: (code: number) => void;
   prompts?: SetupPrompts;
   validateCredentials?: ValidateCredentials;
+  args?: ParsedSetupArgs;
 };
 
 const DEFAULT_PROMPTS: SetupPrompts = {
@@ -63,6 +65,36 @@ const DEFAULT_PROMPTS: SetupPrompts = {
   password: (opts) => inquirerPassword(opts as any),
   confirm: (opts) => inquirerConfirm(opts as any),
 };
+
+export async function runSetupCli(
+  product: ProductDefinition,
+  deps: Omit<SetupDeps, 'args'> = {},
+): Promise<void> {
+  const rawArgv = process.argv.slice(2);
+  const argv = rawArgv[0] === 'setup' ? rawArgv.slice(1) : rawArgv;
+  const exit = deps.exit ?? ((code: number) => { process.exit(code); });
+
+  let args: ParsedSetupArgs;
+  try {
+    args = parseSetupArgs(argv);
+  } catch (error) {
+    if (error instanceof SetupArgsError) {
+      process.stderr.write(`${error.message}\n\n`);
+      printSetupHelp(product.id, (m) => process.stderr.write(`${m}\n`));
+      exit(1);
+      return;
+    }
+    throw error;
+  }
+
+  if (args.help) {
+    printSetupHelp(product.id, (m) => process.stdout.write(`${m}\n`));
+    exit(0);
+    return;
+  }
+
+  await runSetup(product, { ...deps, args });
+}
 
 export async function runSetup(product: ProductDefinition, deps: SetupDeps = {}): Promise<void> {
   const registry = deps.registry ?? buildDefaultRegistry();
@@ -75,10 +107,12 @@ export async function runSetup(product: ProductDefinition, deps: SetupDeps = {})
   log(`Atlassian DC MCP setup — ${product.id}`);
   log('');
 
-  const current = getProductRuntimeConfig(product);
+  const current = readCurrentConfig(registry, product);
   printCurrent(log, registry, product, current);
 
-  const answers = await collectAnswersWithValidation(product, deps, prompts, current, log, exit);
+  const answers = deps.args?.nonInteractive
+    ? await runNonInteractive(product, deps, current, log, exit, deps.args)
+    : await collectAnswersWithValidation(product, deps, prompts, current, log, exit, deps.args);
   if (!answers) {
     return;
   }
@@ -93,16 +127,17 @@ async function collectAnswersWithValidation(
   product: ProductDefinition,
   deps: SetupDeps,
   prompts: SetupPrompts,
-  current: ReturnType<typeof getProductRuntimeConfig>,
+  current: ProductRuntimeConfig,
   log: (message: string) => void,
   exit: (code: number) => void,
+  args: ParsedSetupArgs | undefined,
 ): Promise<PromptResult | undefined> {
   let defaults: PromptDefaults = current;
 
   for (let attempt = 1; ; attempt++) {
     let answers: PromptResult;
     try {
-      answers = await promptForValues(prompts, product, defaults);
+      answers = await promptForValues(prompts, product, defaults, args);
     } catch (error) {
       if (isUserCancel(error)) {
         exit(130);
@@ -153,6 +188,57 @@ async function collectAnswersWithValidation(
   }
 }
 
+async function runNonInteractive(
+  product: ProductDefinition,
+  deps: SetupDeps,
+  current: ProductRuntimeConfig,
+  log: (message: string) => void,
+  exit: (code: number) => void,
+  args: ParsedSetupArgs,
+): Promise<PromptResult | undefined> {
+  let tokenToWrite: string | undefined;
+  let tokenForValidation: string | undefined;
+  if (args.token) {
+    tokenToWrite = args.token;
+    tokenForValidation = args.token;
+  } else if (current.token) {
+    tokenForValidation = current.token;
+  }
+
+  const answers: PromptResult = {
+    host: args.host ?? current.host ?? '',
+    apiBasePath: args.apiBasePath ?? current.apiBasePath ?? product.defaultApiBasePath ?? '',
+    defaultPageSize: args.defaultPageSize ?? String(current.defaultPageSize ?? FALLBACK_PAGE_SIZE),
+    tokenToWrite,
+    tokenForValidation,
+  };
+
+  const formatErrors = validateAnswers(product, answers);
+  if (formatErrors.length > 0) {
+    for (const message of formatErrors) {
+      log(`Validation failed: ${message}`);
+    }
+    exit(1);
+    return undefined;
+  }
+
+  if (deps.validateCredentials && answers.tokenForValidation) {
+    const result = await deps.validateCredentials({
+      host: answers.host,
+      apiBasePath: answers.apiBasePath,
+      token: answers.tokenForValidation,
+    });
+    if (!result.ok) {
+      log(`Validation failed: ${result.message}`);
+      exit(1);
+      return undefined;
+    }
+    log(result.detail ? `Validation succeeded: ${result.detail}` : 'Validation succeeded.');
+  }
+
+  return answers;
+}
+
 function answersAsDefaults(answers: PromptResult): PromptDefaults {
   const pageSize = Number.parseInt(answers.defaultPageSize, 10);
   return {
@@ -184,6 +270,32 @@ async function offerRetryAfterFailure(
   return saveAnyway ? 'save-anyway' : 'abort';
 }
 
+function readCurrentConfig(
+  registry: ConfigRegistry,
+  product: ProductDefinition,
+): ProductRuntimeConfig {
+  const pageSizeRaw = registry.resolve(product, 'defaultPageSize').value;
+  const pageSize = parsePositiveInteger(pageSizeRaw) ?? FALLBACK_PAGE_SIZE;
+  return {
+    host: registry.resolve(product, 'host').value,
+    apiBasePath: registry.resolve(product, 'apiBasePath').value,
+    token: registry.resolve(product, 'token').value,
+    defaultPageSize: pageSize,
+  };
+}
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  return parsed > 0 ? parsed : undefined;
+}
+
 function requireHomeFile(registry: ConfigRegistry): HomeFileSource {
   const homeFile = registry.getWritableSource(
     (s): s is HomeFileSource => s instanceof HomeFileSource,
@@ -198,7 +310,7 @@ function printCurrent(
   log: (message: string) => void,
   registry: ConfigRegistry,
   product: ProductDefinition,
-  current: ReturnType<typeof getProductRuntimeConfig>,
+  current: ProductRuntimeConfig,
 ): void {
   const keys: ConfigKey[] = ['host', 'apiBasePath', 'token', 'defaultPageSize'];
   for (const key of keys) {
@@ -215,23 +327,24 @@ async function promptForValues(
   prompts: SetupPrompts,
   product: ProductDefinition,
   defaults: PromptDefaults,
+  args: ParsedSetupArgs | undefined,
 ): Promise<PromptResult> {
-  const host = await prompts.input({
+  const host = args?.host ?? await prompts.input({
     message: 'Host (e.g. jira.example.com):',
     default: defaults.host ?? '',
     validate: SetupValueValidator.host,
   });
-  const apiBasePath = await prompts.input({
+  const apiBasePath = args?.apiBasePath ?? await prompts.input({
     message: 'API base path:',
     default: defaults.apiBasePath ?? product.defaultApiBasePath ?? '',
     validate: SetupValueValidator.apiBasePath,
   });
-  const defaultPageSize = await prompts.input({
+  const defaultPageSize = args?.defaultPageSize ?? await prompts.input({
     message: 'Default page size:',
     default: String(defaults.defaultPageSize ?? FALLBACK_PAGE_SIZE),
     validate: SetupValueValidator.pageSize,
   });
-  const token = await promptForToken(prompts, defaults.token);
+  const token = await promptForToken(prompts, defaults.token, args?.token);
   return {
     host: host.trim(),
     apiBasePath: apiBasePath.trim(),
@@ -243,7 +356,11 @@ async function promptForValues(
 async function promptForToken(
   prompts: SetupPrompts,
   existing: string | undefined,
+  fromArgs: string | undefined,
 ): Promise<TokenPromptResult> {
+  if (fromArgs) {
+    return { tokenToWrite: fromArgs, tokenForValidation: fromArgs };
+  }
   const entered = await prompts.password({
     message: 'API token:',
     mask: '*',
@@ -268,7 +385,6 @@ function validateAnswers(product: ProductDefinition, answers: PromptResult): str
   for (const [label, value, validator] of [
     ['host', answers.host, SetupValueValidator.host],
     ['API base path', answers.apiBasePath, SetupValueValidator.apiBasePath],
-    ['API token', answers.tokenForValidation ?? '', SetupValueValidator.token],
   ] as const) {
     const result = validator(value);
     if (result !== true) {
@@ -283,6 +399,11 @@ function validateAnswers(product: ProductDefinition, answers: PromptResult): str
 
   if (!answers.tokenForValidation) {
     errors.push(`API token is required (${product.envVars.token}).`);
+  } else {
+    const tokenResult = SetupValueValidator.token(answers.tokenForValidation);
+    if (tokenResult !== true) {
+      errors.push(`API token: ${tokenResult}`);
+    }
   }
 
   const hasHost = answers.host.length > 0;

--- a/packages/common/src/setup/args.ts
+++ b/packages/common/src/setup/args.ts
@@ -1,0 +1,78 @@
+import { parseArgs } from 'node:util';
+
+export type ParsedSetupArgs = {
+  host?: string;
+  apiBasePath?: string;
+  token?: string;
+  defaultPageSize?: string;
+  nonInteractive: boolean;
+  help: boolean;
+};
+
+export class SetupArgsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SetupArgsError';
+  }
+}
+
+export function parseSetupArgs(argv: readonly string[]): ParsedSetupArgs {
+  let values;
+  try {
+    ({ values } = parseArgs({
+      args: [...argv],
+      options: {
+        host: { type: 'string', short: 'H' },
+        'api-base-path': { type: 'string', short: 'b' },
+        token: { type: 'string', short: 't' },
+        'default-page-size': { type: 'string', short: 's' },
+        'non-interactive': { type: 'boolean', short: 'n', default: false },
+        help: { type: 'boolean', short: 'h', default: false },
+      },
+      strict: true,
+      allowPositionals: false,
+    }));
+  } catch (error) {
+    throw new SetupArgsError((error as Error).message);
+  }
+
+  return {
+    host: trimToUndefined(values.host),
+    apiBasePath: trimToUndefined(values['api-base-path']),
+    token: trimToUndefined(values.token),
+    defaultPageSize: trimToUndefined(values['default-page-size']),
+    nonInteractive: values['non-interactive'] === true,
+    help: values.help === true,
+  };
+}
+
+function trimToUndefined(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
+export function printSetupHelp(productId: string, log: (message: string) => void): void {
+  const lines = [
+    `Usage: @atlassian-dc-mcp/${productId} setup [options]`,
+    '',
+    'Options:',
+    '  -H, --host <value>          Host (e.g. jira.example.com)',
+    '  -b, --api-base-path <value> API base path or full URL',
+    '  -t, --token <value>         API token',
+    '  -s, --default-page-size <n> Default page size (positive integer)',
+    '  -n, --non-interactive       Skip prompts; fail if a required value is missing',
+    '  -h, --help                  Show this help and exit',
+    '',
+    'In interactive mode (default), any value not passed as a flag is collected via prompts.',
+    'In --non-interactive mode, missing values fall back to existing configuration',
+    `(process env, ~/.atlassian-dc-mcp/${productId}.env, or macOS Keychain), and the run`,
+    'fails if a host (or full-URL --api-base-path) and token cannot be resolved.',
+    'An existing token is reused when --token is omitted.',
+  ];
+  for (const line of lines) {
+    log(line);
+  }
+}

--- a/packages/confluence/README.md
+++ b/packages/confluence/README.md
@@ -31,6 +31,18 @@ After setup, you can launch the server without any environment variables:
 
 Environment variables still override stored values — see [Configuration sources](#configuration-sources) below.
 
+### Scripted / non-interactive setup
+
+For CI, remote sessions, or shell scripts, pass values as flags and add `--non-interactive` to skip prompts:
+
+```bash
+npx @atlassian-dc-mcp/confluence setup --non-interactive \
+  --host confluence.example.com \
+  --token "$CONFLUENCE_TOKEN"
+```
+
+Available flags: `--host`/`-H`, `--api-base-path`/`-b`, `--token`/`-t`, `--default-page-size`/`-s`, `--non-interactive`/`-n`, `--help`/`-h`. In `--non-interactive` mode, missing values fall back to existing configuration and the run exits non-zero if a host (or full-URL `--api-base-path`) and token cannot be resolved. An existing token is reused when `--token` is omitted. Run `npx @atlassian-dc-mcp/confluence setup --help` for full usage.
+
 ## Features
 
 - Get content by ID

--- a/packages/confluence/src/setup.ts
+++ b/packages/confluence/src/setup.ts
@@ -1,8 +1,8 @@
-import { describeValidationError, runSetup } from '@atlassian-dc-mcp/common';
+import { describeValidationError, runSetupCli } from '@atlassian-dc-mcp/common';
 import { CONFLUENCE_PRODUCT } from './config.js';
 import { ConfluenceService } from './confluence-service.js';
 
-await runSetup(CONFLUENCE_PRODUCT, {
+await runSetupCli(CONFLUENCE_PRODUCT, {
   validateCredentials: async ({ host, apiBasePath, token }) => {
     const service = new ConfluenceService(host || undefined, token, apiBasePath || undefined);
     try {

--- a/packages/jira/README.md
+++ b/packages/jira/README.md
@@ -31,6 +31,18 @@ After setup, you can launch the server without any environment variables:
 
 Environment variables still override stored values — see [Configuration sources](#configuration-sources) below.
 
+### Scripted / non-interactive setup
+
+For CI, remote sessions, or shell scripts, pass values as flags and add `--non-interactive` to skip prompts:
+
+```bash
+npx @atlassian-dc-mcp/jira setup --non-interactive \
+  --host jira.example.com \
+  --token "$JIRA_TOKEN"
+```
+
+Available flags: `--host`/`-H`, `--api-base-path`/`-b`, `--token`/`-t`, `--default-page-size`/`-s`, `--non-interactive`/`-n`, `--help`/`-h`. In `--non-interactive` mode, missing values fall back to existing configuration and the run exits non-zero if a host (or full-URL `--api-base-path`) and token cannot be resolved. An existing token is reused when `--token` is omitted. Run `npx @atlassian-dc-mcp/jira setup --help` for full usage.
+
 ## Claude Desktop Configuration
 
 To use this MCP connector with Claude Desktop, add the following to your Claude Desktop configuration:

--- a/packages/jira/src/setup.ts
+++ b/packages/jira/src/setup.ts
@@ -1,8 +1,8 @@
-import { describeValidationError, runSetup } from '@atlassian-dc-mcp/common';
+import { describeValidationError, runSetupCli } from '@atlassian-dc-mcp/common';
 import { JIRA_PRODUCT } from './config.js';
 import { JiraService } from './jira-service.js';
 
-await runSetup(JIRA_PRODUCT, {
+await runSetupCli(JIRA_PRODUCT, {
   validateCredentials: async ({ host, apiBasePath, token }) => {
     const service = new JiraService(host || undefined, token, apiBasePath || undefined);
     try {


### PR DESCRIPTION
## Summary

Adds CLI flags and a `--non-interactive` mode to the per-product `setup` subcommand so it can be driven from scripts, CI, or remote sessions without losing the existing interactive flow as the default.

### What's new

- **CLI flags** (parsed via `node:util` `parseArgs`):
  - `--host`/`-H`, `--api-base-path`/`-b`, `--token`/`-t`, `--default-page-size`/`-s`, `--non-interactive`/`-n`, `--help`/`-h`
- **Interactive mode** — any flag you pass prefills its prompt (e.g. `--host` skips just the host prompt). Unchanged otherwise.
- **`--non-interactive` mode** — resolves missing values from existing configuration (process env, `~/.atlassian-dc-mcp/<product>.env`, or macOS Keychain) and exits non-zero if a host (or full-URL `--api-base-path`) and token cannot be found. Skips retry/save-anyway prompts on validation failure so it can be used as a CI gate.
- **Token reuse** — an existing token from the registry is reused when `--token` is omitted, so re-validating doesn't require re-entering it.
- **`runSetupCli` helper** in the common package consolidates arg parsing, `--help`, and error reporting; each per-product `setup.ts` becomes a thin wrapper.

### Why

The current setup CLI requires a TTY and human input for every value. That blocks scripted bootstrap (provisioning a workstation, refreshing a token in CI, re-validating an env after rotation), and it's awkward to drive over remote shells. Adding flags + a non-interactive mode keeps the friendly interactive default while unblocking those flows.

### Files

- `packages/common/src/setup/args.ts` — new `parseSetupArgs` / `printSetupHelp` / `SetupArgsError`.
- `packages/common/src/setup-cli.ts` — new non-interactive branch, new `runSetupCli` helper, cleaner token-validation in `validateAnswers`.
- `packages/common/src/index.ts` — exports for the new helpers.
- `packages/{jira,confluence,bitbucket}/src/setup.ts` — slimmed down to use `runSetupCli`.
- `README.md` and per-product READMEs — documented flags, non-interactive mode, and a scripted-setup example.

### Tests

- `packages/common/src/__tests__/args.test.ts` — covers parsing, short/long flag aliases, trimming, unknown-flag errors, stray-positional errors, help output.
- `packages/common/src/__tests__/setup-cli.test.ts` — adds a non-interactive `describe` block: writes from CLI args without prompts, exits 1 on missing token, reuses an existing keychain token, format-error exit on bad page size, exits 1 on credential rejection without retry, and falls back to `defaultApiBasePath` / `FALLBACK_PAGE_SIZE` for unspecified optional fields. Plus an interactive case that confirms `--host` skips just the host prompt.

All 94 tests pass; build is clean.

## Test plan

- [x] `npm run build`
- [x] `npm run test` (10 suites, 94 tests)
- [x] Smoke test: `node packages/jira/bin/run.js setup --help` → exits 0 with usage
- [x] Smoke test: `node packages/jira/bin/run.js setup --bogus` → exits 1 with error + usage on stderr
- [x] Smoke test: direct invocation `node packages/jira/build/setup.js --help` also works (helper strips a leading `setup` subcommand if present)
- [x] Reviewer: verify the documented flags in `README.md` match the help output