### PR TITLE
feat(confluence): add upload & download attachment tools

### DIFF
--- a/packages/common/src/__tests__/attachment-download.test.ts
+++ b/packages/common/src/__tests__/attachment-download.test.ts
@@ -1,34 +1,37 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { downloadAttachment, resolveSafeChildPath } from '../attachment-download.js';
+import { downloadAttachment } from '../attachment-download.js';
 
-function mockFetchOnce(body: Buffer, init?: { ok?: boolean; status?: number; statusText?: string; contentType?: string }) {
+function mockFetchOnce(
+  body: Buffer,
+  init?: { ok?: boolean; status?: number; statusText?: string; contentType?: string; contentLength?: string; stream?: boolean },
+) {
   const ok = init?.ok ?? true;
-  global.fetch = jest.fn().mockResolvedValue({
+  const headers = new Map<string, string>();
+  if (init?.contentType) headers.set('content-type', init.contentType);
+  if (init?.contentLength) headers.set('content-length', init.contentLength);
+
+  const response: Record<string, unknown> = {
     ok,
     status: init?.status ?? (ok ? 200 : 500),
     statusText: init?.statusText ?? (ok ? 'OK' : 'Error'),
-    headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? init?.contentType ?? null : null) },
+    headers: { get: (name: string) => headers.get(name.toLowerCase()) ?? null },
     arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
-  }) as unknown as typeof fetch;
+  };
+
+  if (init?.stream) {
+    let sent = false;
+    response.body = {
+      getReader: () => ({
+        read: async () => (sent ? { done: true, value: undefined } : ((sent = true), { done: false, value: new Uint8Array(body) })),
+        cancel: async () => undefined,
+      }),
+    };
+  }
+
+  global.fetch = jest.fn().mockResolvedValue(response) as unknown as typeof fetch;
 }
-
-describe('resolveSafeChildPath', () => {
-  it('joins the basename of the filename to the directory', () => {
-    expect(resolveSafeChildPath('/tmp/out', 'file.txt')).toBe(path.resolve('/tmp/out', 'file.txt'));
-  });
-
-  it('strips directory components from the filename (traversal defense)', () => {
-    expect(resolveSafeChildPath('/tmp/out', '../../etc/passwd')).toBe(path.resolve('/tmp/out', 'passwd'));
-    expect(resolveSafeChildPath('/tmp/out', '/etc/passwd')).toBe(path.resolve('/tmp/out', 'passwd'));
-  });
-
-  it('rejects filenames that resolve to the directory itself', () => {
-    expect(() => resolveSafeChildPath('/tmp/out', '..')).toThrow();
-    expect(() => resolveSafeChildPath('/tmp/out', '.')).toThrow();
-  });
-});
 
 describe('downloadAttachment', () => {
   let tmpDir: string;
@@ -42,23 +45,35 @@ describe('downloadAttachment', () => {
     jest.restoreAllMocks();
   });
 
-  it('saves the file to saveDir using the filename and reports metadata', async () => {
+  it('writes the file to the provided destination and reports metadata', async () => {
     mockFetchOnce(Buffer.from('hello world'), { contentType: 'text/plain' });
+    const destination = path.join(tmpDir, 'note.txt');
 
     const result = await downloadAttachment({
       url: 'https://host/download/x',
       token: 'tok',
       filename: 'note.txt',
-      options: { saveDir: tmpDir },
+      options: { destination },
     });
 
     expect(global.fetch).toHaveBeenCalledWith('https://host/download/x', {
       headers: { Authorization: 'Bearer tok', 'X-Atlassian-Token': 'nocheck' },
     });
-    expect(result.savedPath).toBe(path.join(tmpDir, 'note.txt'));
+    expect(result.savedPath).toBe(destination);
     expect(result.size).toBe(11);
-    expect(fs.readFileSync(result.savedPath!, 'utf-8')).toBe('hello world');
+    expect(fs.readFileSync(destination, 'utf-8')).toBe('hello world');
     expect(result.content).toBeUndefined();
+  });
+
+  it('refuses to overwrite an existing destination file', async () => {
+    mockFetchOnce(Buffer.from('new content'));
+    const destination = path.join(tmpDir, 'exists.txt');
+    fs.writeFileSync(destination, 'original');
+
+    await expect(
+      downloadAttachment({ url: 'https://host/x', token: 'tok', filename: 'exists.txt', options: { destination } }),
+    ).rejects.toThrow();
+    expect(fs.readFileSync(destination, 'utf-8')).toBe('original');
   });
 
   it('returns text content inline when requested', async () => {
@@ -103,6 +118,30 @@ describe('downloadAttachment', () => {
 
     expect(result.content).toBeUndefined();
     expect(result.contentOmittedReason).toContain('exceeds inline cap');
+  });
+
+  it('rejects early when content-length exceeds the download cap', async () => {
+    mockFetchOnce(Buffer.from('1234567890'), { contentLength: '10' });
+
+    await expect(
+      downloadAttachment({ url: 'https://host/x', token: 'tok', filename: 'big.bin', options: { maxDownloadBytes: 5 } }),
+    ).rejects.toThrow('exceeds the configured download limit');
+  });
+
+  it('aborts a streamed body that exceeds the download cap', async () => {
+    mockFetchOnce(Buffer.from('1234567890'), { stream: true });
+
+    await expect(
+      downloadAttachment({ url: 'https://host/x', token: 'tok', filename: 'big.bin', options: { maxDownloadBytes: 5 } }),
+    ).rejects.toThrow('exceeds the configured download limit');
+  });
+
+  it('enforces the cap on a buffered body without content-length', async () => {
+    mockFetchOnce(Buffer.from('1234567890'));
+
+    await expect(
+      downloadAttachment({ url: 'https://host/x', token: 'tok', filename: 'big.bin', options: { maxDownloadBytes: 5 } }),
+    ).rejects.toThrow('exceeds the configured download limit');
   });
 
   it('throws when the response is not ok', async () => {

--- a/packages/common/src/__tests__/attachment-download.test.ts
+++ b/packages/common/src/__tests__/attachment-download.test.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { downloadAttachment, resolveSafeChildPath } from '../attachment-download.js';
+
+function mockFetchOnce(body: Buffer, init?: { ok?: boolean; status?: number; statusText?: string; contentType?: string }) {
+  const ok = init?.ok ?? true;
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    status: init?.status ?? (ok ? 200 : 500),
+    statusText: init?.statusText ?? (ok ? 'OK' : 'Error'),
+    headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? init?.contentType ?? null : null) },
+    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+  }) as unknown as typeof fetch;
+}
+
+describe('resolveSafeChildPath', () => {
+  it('joins the basename of the filename to the directory', () => {
+    expect(resolveSafeChildPath('/tmp/out', 'file.txt')).toBe(path.resolve('/tmp/out', 'file.txt'));
+  });
+
+  it('strips directory components from the filename (traversal defense)', () => {
+    expect(resolveSafeChildPath('/tmp/out', '../../etc/passwd')).toBe(path.resolve('/tmp/out', 'passwd'));
+    expect(resolveSafeChildPath('/tmp/out', '/etc/passwd')).toBe(path.resolve('/tmp/out', 'passwd'));
+  });
+
+  it('rejects filenames that resolve to the directory itself', () => {
+    expect(() => resolveSafeChildPath('/tmp/out', '..')).toThrow();
+    expect(() => resolveSafeChildPath('/tmp/out', '.')).toThrow();
+  });
+});
+
+describe('downloadAttachment', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mcp-dl-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  it('saves the file to saveDir using the filename and reports metadata', async () => {
+    mockFetchOnce(Buffer.from('hello world'), { contentType: 'text/plain' });
+
+    const result = await downloadAttachment({
+      url: 'https://host/download/x',
+      token: 'tok',
+      filename: 'note.txt',
+      options: { saveDir: tmpDir },
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('https://host/download/x', {
+      headers: { Authorization: 'Bearer tok', 'X-Atlassian-Token': 'nocheck' },
+    });
+    expect(result.savedPath).toBe(path.join(tmpDir, 'note.txt'));
+    expect(result.size).toBe(11);
+    expect(fs.readFileSync(result.savedPath!, 'utf-8')).toBe('hello world');
+    expect(result.content).toBeUndefined();
+  });
+
+  it('returns text content inline when requested', async () => {
+    mockFetchOnce(Buffer.from('inline text'));
+
+    const result = await downloadAttachment({
+      url: 'https://host/download/x',
+      token: () => 'tok',
+      filename: 'note.txt',
+      options: { returnContent: 'text' },
+    });
+
+    expect(result.content).toBe('inline text');
+    expect(result.encoding).toBe('text');
+    expect(result.savedPath).toBeUndefined();
+  });
+
+  it('returns base64 content inline when requested', async () => {
+    const bytes = Buffer.from([0x00, 0x01, 0x02, 0xff]);
+    mockFetchOnce(bytes);
+
+    const result = await downloadAttachment({
+      url: 'https://host/download/x',
+      token: 'tok',
+      filename: 'blob.bin',
+      options: { returnContent: 'base64' },
+    });
+
+    expect(result.content).toBe(bytes.toString('base64'));
+    expect(result.encoding).toBe('base64');
+  });
+
+  it('omits inline content when the file exceeds maxInlineBytes', async () => {
+    mockFetchOnce(Buffer.from('123456'));
+
+    const result = await downloadAttachment({
+      url: 'https://host/download/x',
+      token: 'tok',
+      filename: 'big.txt',
+      options: { returnContent: 'text', maxInlineBytes: 3 },
+    });
+
+    expect(result.content).toBeUndefined();
+    expect(result.contentOmittedReason).toContain('exceeds inline cap');
+  });
+
+  it('throws when the response is not ok', async () => {
+    mockFetchOnce(Buffer.from(''), { ok: false, status: 404, statusText: 'Not Found' });
+
+    await expect(
+      downloadAttachment({ url: 'https://host/x', token: 'tok', filename: 'f.txt' }),
+    ).rejects.toThrow('404 Not Found');
+  });
+
+  it('throws when no token is available', async () => {
+    mockFetchOnce(Buffer.from(''));
+
+    await expect(
+      downloadAttachment({ url: 'https://host/x', token: () => undefined, filename: 'f.txt' }),
+    ).rejects.toThrow('Missing API token');
+  });
+});

--- a/packages/common/src/__tests__/attachment-gateway.test.ts
+++ b/packages/common/src/__tests__/attachment-gateway.test.ts
@@ -1,0 +1,156 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DEFAULT_MAX_ATTACHMENT_BYTES,
+  resolveAttachmentGateway,
+  resolveDownloadDestination,
+  resolveUploadSource,
+} from '../attachment-gateway.js';
+import type { ProductDefinition } from '../config/source.js';
+
+const PRODUCT: ProductDefinition = {
+  id: 'jira',
+  envVars: { host: 'JIRA_HOST', apiBasePath: 'JIRA_API_BASE_PATH', token: 'JIRA_API_TOKEN', defaultPageSize: 'JIRA_DEFAULT_PAGE_SIZE' },
+};
+
+const silentWarn = () => undefined;
+
+describe('resolveAttachmentGateway', () => {
+  let root: string;
+  let realRoot: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mcp-gw-'));
+    realRoot = fs.realpathSync(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('is disabled by default', () => {
+    const gw = resolveAttachmentGateway(PRODUCT, { env: {}, warn: silentWarn });
+    expect(gw.upload.enabled).toBe(false);
+    expect(gw.download.enabled).toBe(false);
+  });
+
+  it('stays disabled when enabled but no valid root is configured', () => {
+    const gw = resolveAttachmentGateway(PRODUCT, {
+      env: { JIRA_ATTACHMENTS_UPLOAD_ENABLED: 'true' },
+      warn: silentWarn,
+    });
+    expect(gw.upload.enabled).toBe(false);
+  });
+
+  it('enables upload with a canonical root and default size limit', () => {
+    const gw = resolveAttachmentGateway(PRODUCT, {
+      env: { JIRA_ATTACHMENTS_UPLOAD_ENABLED: 'true', JIRA_ATTACHMENTS_UPLOAD_ROOTS: root },
+      warn: silentWarn,
+    });
+    expect(gw.upload.enabled).toBe(true);
+    expect(gw.upload.roots).toEqual([realRoot]);
+    expect(gw.upload.maxBytes).toBe(DEFAULT_MAX_ATTACHMENT_BYTES);
+  });
+
+  it('uses JIRA_ATTACHMENTS_DIR as a shared exchange root and honours size overrides', () => {
+    const gw = resolveAttachmentGateway(PRODUCT, {
+      env: {
+        JIRA_ATTACHMENTS_UPLOAD_ENABLED: 'true',
+        JIRA_ATTACHMENTS_DOWNLOAD_ENABLED: '1',
+        JIRA_ATTACHMENTS_DIR: root,
+        JIRA_ATTACHMENTS_MAX_UPLOAD_BYTES: '1024',
+      },
+      warn: silentWarn,
+    });
+    expect(gw.upload.roots).toEqual([realRoot]);
+    expect(gw.download.roots).toEqual([realRoot]);
+    expect(gw.upload.maxBytes).toBe(1024);
+  });
+});
+
+describe('resolveUploadSource', () => {
+  let root: string;
+  const side = () => ({ enabled: true, roots: [fs.realpathSync(root)], maxBytes: 100 });
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mcp-up-'));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('resolves a regular file inside the root', async () => {
+    fs.writeFileSync(path.join(root, 'a.txt'), 'hi');
+    const { absolutePath, size } = await resolveUploadSource({ requestedPath: 'a.txt', side: side() });
+    expect(absolutePath).toBe(path.join(fs.realpathSync(root), 'a.txt'));
+    expect(size).toBe(2);
+  });
+
+  it('rejects absolute paths', async () => {
+    await expect(resolveUploadSource({ requestedPath: '/etc/passwd', side: side() })).rejects.toThrow('not absolute');
+  });
+
+  it('rejects traversal outside the root', async () => {
+    await expect(resolveUploadSource({ requestedPath: '../secret', side: side() })).rejects.toThrow('within the configured');
+  });
+
+  it('rejects a symlink leaf', async () => {
+    const target = path.join(root, 'real.txt');
+    fs.writeFileSync(target, 'secret');
+    fs.symlinkSync(target, path.join(root, 'link.txt'));
+    await expect(resolveUploadSource({ requestedPath: 'link.txt', side: side() })).rejects.toThrow('symlink');
+  });
+
+  it('rejects a path that escapes via a symlinked directory', async () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mcp-out-'));
+    fs.writeFileSync(path.join(outside, 'secret.txt'), 'x');
+    fs.symlinkSync(outside, path.join(root, 'escape'));
+    await expect(resolveUploadSource({ requestedPath: 'escape/secret.txt', side: side() })).rejects.toThrow('outside');
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  it('rejects a non-regular file (directory)', async () => {
+    fs.mkdirSync(path.join(root, 'sub'));
+    await expect(resolveUploadSource({ requestedPath: 'sub', side: side() })).rejects.toThrow('non-regular');
+  });
+
+  it('rejects a file over the size limit', async () => {
+    fs.writeFileSync(path.join(root, 'big.txt'), 'x'.repeat(200));
+    await expect(resolveUploadSource({ requestedPath: 'big.txt', side: side() })).rejects.toThrow('exceeds the configured upload limit');
+  });
+
+  it('throws when upload is disabled', async () => {
+    await expect(
+      resolveUploadSource({ requestedPath: 'a.txt', side: { enabled: false, roots: [], maxBytes: 100 } }),
+    ).rejects.toThrow('disabled');
+  });
+});
+
+describe('resolveDownloadDestination', () => {
+  let root: string;
+  const side = () => ({ enabled: true, roots: [fs.realpathSync(root)], maxBytes: 100 });
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mcp-dd-'));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('resolves a basename into the download root', async () => {
+    const dest = await resolveDownloadDestination({ requestedName: 'out.bin', side: side() });
+    expect(dest).toBe(path.join(fs.realpathSync(root), 'out.bin'));
+  });
+
+  it('strips directory components from the requested name', async () => {
+    const dest = await resolveDownloadDestination({ requestedName: '../../etc/passwd', side: side() });
+    expect(dest).toBe(path.join(fs.realpathSync(root), 'passwd'));
+  });
+
+  it('throws when saving is disabled', async () => {
+    await expect(
+      resolveDownloadDestination({ requestedName: 'out.bin', side: { enabled: false, roots: [], maxBytes: 100 } }),
+    ).rejects.toThrow('disabled');
+  });
+});

--- a/packages/common/src/attachment-download.ts
+++ b/packages/common/src/attachment-download.ts
@@ -1,5 +1,5 @@
-import { mkdir, writeFile } from 'node:fs/promises';
-import { basename, dirname, isAbsolute, resolve, sep } from 'node:path';
+import { writeFile } from 'node:fs/promises';
+import { basename } from 'node:path';
 
 /**
  * How the downloaded bytes should be returned to the caller inline, in addition
@@ -14,14 +14,19 @@ export type AttachmentContentEncoding = 'none' | 'base64' | 'text';
 export const DEFAULT_MAX_INLINE_BYTES = 1_048_576;
 
 export interface AttachmentDownloadOptions {
-  /** Explicit destination file path. Takes precedence over saveDir. */
-  savePath?: string;
-  /** Destination directory; the (sanitized) filename is appended to it. */
-  saveDir?: string;
+  /**
+   * Absolute, already-validated destination path to write the bytes to. Resolving
+   * and sandboxing this path is the caller's responsibility (see the attachment
+   * gateway); the file is written with an exclusive flag and never overwrites an
+   * existing file. When omitted, nothing is written to disk.
+   */
+  destination?: string;
   /** Whether and how to embed the bytes in the response. Defaults to `none`. */
   returnContent?: AttachmentContentEncoding;
   /** Maximum bytes to embed inline when returnContent is not `none`. */
   maxInlineBytes?: number;
+  /** Hard cap on the number of downloaded bytes. Exceeding it aborts the download. */
+  maxDownloadBytes?: number;
 }
 
 export interface AttachmentDownloadResult {
@@ -47,39 +52,47 @@ async function resolveToken(token: string | (() => string | undefined)): Promise
 }
 
 /**
- * Resolves a destination path for a downloaded file inside `saveDir`, guarding
- * against path traversal: only the basename of `filename` is used, and the
- * resolved path must stay within `saveDir`.
+ * Reads the response body, enforcing `cap` (when set) without buffering more than
+ * the limit. Streams chunk-by-chunk when a web ReadableStream is available and
+ * falls back to a buffered read with a post-check otherwise.
  */
-export function resolveSafeChildPath(saveDir: string, filename: string): string {
-  const safeName = basename(filename);
-  if (!safeName || safeName === '.' || safeName === '..') {
-    throw new Error(`Unsafe attachment filename: "${filename}"`);
+async function readBodyWithCap(response: Response, cap: number | undefined, filename: string): Promise<Buffer> {
+  const body = response.body as ReadableStream<Uint8Array> | null;
+  if (cap !== undefined && body && typeof body.getReader === 'function') {
+    const reader = body.getReader();
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      total += value.byteLength;
+      if (total > cap) {
+        await reader.cancel();
+        throw new Error(`Attachment "${filename}" exceeds the configured download limit of ${cap} bytes`);
+      }
+      chunks.push(Buffer.from(value));
+    }
+    return Buffer.concat(chunks);
   }
-  const baseDir = resolve(saveDir);
-  const target = resolve(baseDir, safeName);
-  if (target !== baseDir && !target.startsWith(baseDir + sep)) {
-    throw new Error(`Refusing to write outside of target directory: "${filename}"`);
-  }
-  return target;
-}
 
-function resolveDestination(filename: string, options: AttachmentDownloadOptions): string | undefined {
-  if (options.savePath) {
-    return isAbsolute(options.savePath) ? options.savePath : resolve(options.savePath);
+  const buffer = Buffer.from(await response.arrayBuffer());
+  if (cap !== undefined && buffer.length > cap) {
+    throw new Error(
+      `Attachment "${filename}" size ${buffer.length} bytes exceeds the configured download limit of ${cap} bytes`,
+    );
   }
-  if (options.saveDir) {
-    return resolveSafeChildPath(options.saveDir, filename);
-  }
-  return undefined;
+  return buffer;
 }
 
 /**
  * Downloads a file from an authenticated Atlassian Data Center URL using a
- * Bearer token, optionally writing it to disk and/or returning its bytes inline.
+ * Bearer token, optionally writing it to a pre-validated destination and/or
+ * returning its bytes inline.
  *
- * The bytes are buffered in memory; this is intended for typical attachment
- * sizes rather than very large files.
+ * Writing uses an exclusive flag, so an existing file (including a symlink) is
+ * never overwritten.
  */
 export async function downloadAttachment(params: {
   url: string;
@@ -104,7 +117,15 @@ export async function downloadAttachment(params: {
     throw new Error(`Failed to download attachment "${filename}": ${response.status} ${response.statusText}`);
   }
 
-  const buffer = Buffer.from(await response.arrayBuffer());
+  const cap = options.maxDownloadBytes;
+  const declaredLength = Number(response.headers.get('content-length'));
+  if (cap !== undefined && Number.isFinite(declaredLength) && declaredLength > cap) {
+    throw new Error(
+      `Attachment "${filename}" size ${declaredLength} bytes exceeds the configured download limit of ${cap} bytes`,
+    );
+  }
+
+  const buffer = await readBodyWithCap(response, cap, filename);
   const resolvedMediaType = mediaType ?? response.headers.get('content-type') ?? undefined;
 
   const result: AttachmentDownloadResult = {
@@ -113,18 +134,16 @@ export async function downloadAttachment(params: {
     size: buffer.length,
   };
 
-  const destination = resolveDestination(filename, options);
-  if (destination) {
-    await mkdir(dirname(destination), { recursive: true });
-    await writeFile(destination, buffer);
-    result.savedPath = destination;
+  if (options.destination) {
+    await writeFile(options.destination, buffer, { flag: 'wx' });
+    result.savedPath = options.destination;
   }
 
   const returnContent = options.returnContent ?? 'none';
   if (returnContent !== 'none') {
-    const cap = options.maxInlineBytes ?? DEFAULT_MAX_INLINE_BYTES;
-    if (buffer.length > cap) {
-      result.contentOmittedReason = `File size ${buffer.length} bytes exceeds inline cap of ${cap} bytes`;
+    const inlineCap = options.maxInlineBytes ?? DEFAULT_MAX_INLINE_BYTES;
+    if (buffer.length > inlineCap) {
+      result.contentOmittedReason = `File size ${buffer.length} bytes exceeds inline cap of ${inlineCap} bytes`;
     } else {
       result.content = returnContent === 'base64' ? buffer.toString('base64') : buffer.toString('utf-8');
       result.encoding = returnContent;

--- a/packages/common/src/attachment-download.ts
+++ b/packages/common/src/attachment-download.ts
@@ -1,0 +1,135 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, resolve, sep } from 'node:path';
+
+/**
+ * How the downloaded bytes should be returned to the caller inline, in addition
+ * to (or instead of) being written to disk.
+ * - `none`: do not embed the bytes in the response (default)
+ * - `base64`: embed base64-encoded bytes (suitable for binary files)
+ * - `text`: embed the bytes decoded as UTF-8 text (suitable for text files)
+ */
+export type AttachmentContentEncoding = 'none' | 'base64' | 'text';
+
+/** Default cap for inline content so responses do not balloon. 1 MiB. */
+export const DEFAULT_MAX_INLINE_BYTES = 1_048_576;
+
+export interface AttachmentDownloadOptions {
+  /** Explicit destination file path. Takes precedence over saveDir. */
+  savePath?: string;
+  /** Destination directory; the (sanitized) filename is appended to it. */
+  saveDir?: string;
+  /** Whether and how to embed the bytes in the response. Defaults to `none`. */
+  returnContent?: AttachmentContentEncoding;
+  /** Maximum bytes to embed inline when returnContent is not `none`. */
+  maxInlineBytes?: number;
+}
+
+export interface AttachmentDownloadResult {
+  filename: string;
+  mediaType?: string;
+  /** Number of bytes downloaded. */
+  size: number;
+  /** Absolute path the file was written to, when saving was requested. */
+  savedPath?: string;
+  /** Inline content, when returnContent is `base64` or `text`. */
+  content?: string;
+  encoding?: 'base64' | 'text';
+  /** Set when inline content was requested but omitted (e.g. over the size cap). */
+  contentOmittedReason?: string;
+}
+
+async function resolveToken(token: string | (() => string | undefined)): Promise<string> {
+  const resolved = typeof token === 'function' ? token() : token;
+  if (!resolved) {
+    throw new Error('Missing API token for attachment download');
+  }
+  return resolved;
+}
+
+/**
+ * Resolves a destination path for a downloaded file inside `saveDir`, guarding
+ * against path traversal: only the basename of `filename` is used, and the
+ * resolved path must stay within `saveDir`.
+ */
+export function resolveSafeChildPath(saveDir: string, filename: string): string {
+  const safeName = basename(filename);
+  if (!safeName || safeName === '.' || safeName === '..') {
+    throw new Error(`Unsafe attachment filename: "${filename}"`);
+  }
+  const baseDir = resolve(saveDir);
+  const target = resolve(baseDir, safeName);
+  if (target !== baseDir && !target.startsWith(baseDir + sep)) {
+    throw new Error(`Refusing to write outside of target directory: "${filename}"`);
+  }
+  return target;
+}
+
+function resolveDestination(filename: string, options: AttachmentDownloadOptions): string | undefined {
+  if (options.savePath) {
+    return isAbsolute(options.savePath) ? options.savePath : resolve(options.savePath);
+  }
+  if (options.saveDir) {
+    return resolveSafeChildPath(options.saveDir, filename);
+  }
+  return undefined;
+}
+
+/**
+ * Downloads a file from an authenticated Atlassian Data Center URL using a
+ * Bearer token, optionally writing it to disk and/or returning its bytes inline.
+ *
+ * The bytes are buffered in memory; this is intended for typical attachment
+ * sizes rather than very large files.
+ */
+export async function downloadAttachment(params: {
+  url: string;
+  token: string | (() => string | undefined);
+  filename: string;
+  mediaType?: string;
+  options?: AttachmentDownloadOptions;
+}): Promise<AttachmentDownloadResult> {
+  const { url, filename, mediaType } = params;
+  const options = params.options ?? {};
+  const token = await resolveToken(params.token);
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      // Attachment download endpoints are XSRF-protected; nocheck bypasses it.
+      'X-Atlassian-Token': 'nocheck',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to download attachment "${filename}": ${response.status} ${response.statusText}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const resolvedMediaType = mediaType ?? response.headers.get('content-type') ?? undefined;
+
+  const result: AttachmentDownloadResult = {
+    filename: basename(filename),
+    mediaType: resolvedMediaType,
+    size: buffer.length,
+  };
+
+  const destination = resolveDestination(filename, options);
+  if (destination) {
+    await mkdir(dirname(destination), { recursive: true });
+    await writeFile(destination, buffer);
+    result.savedPath = destination;
+  }
+
+  const returnContent = options.returnContent ?? 'none';
+  if (returnContent !== 'none') {
+    const cap = options.maxInlineBytes ?? DEFAULT_MAX_INLINE_BYTES;
+    if (buffer.length > cap) {
+      result.contentOmittedReason = `File size ${buffer.length} bytes exceeds inline cap of ${cap} bytes`;
+    } else {
+      result.content = returnContent === 'base64' ? buffer.toString('base64') : buffer.toString('utf-8');
+      result.encoding = returnContent;
+    }
+  }
+
+  return result;
+}

--- a/packages/common/src/attachment-gateway.ts
+++ b/packages/common/src/attachment-gateway.ts
@@ -1,0 +1,255 @@
+import { realpathSync } from 'node:fs';
+import { lstat, realpath } from 'node:fs/promises';
+import { basename, delimiter, dirname, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
+import type { ProductDefinition } from './config/source.js';
+
+/**
+ * Operator-controlled gateway that lets the attachment tools read from / write to
+ * the local filesystem. It is disabled by default: filesystem access must be
+ * explicitly enabled and confined to canonical root directories that the model
+ * cannot choose. Configured entirely through environment variables named after
+ * the product (e.g. JIRA_ATTACHMENTS_*).
+ */
+export const DEFAULT_MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024; // 25 MiB
+
+export interface AttachmentGatewaySide {
+  /** Whether this direction (upload/download) is enabled with a valid root. */
+  enabled: boolean;
+  /** Canonical (realpath-resolved) absolute root directories. */
+  roots: string[];
+  /** Hard byte limit for a single file in this direction. */
+  maxBytes: number;
+}
+
+export interface AttachmentGateway {
+  upload: AttachmentGatewaySide;
+  download: AttachmentGatewaySide;
+}
+
+type Env = Record<string, string | undefined>;
+type Warn = (message: string) => void;
+
+function envPrefix(product: ProductDefinition): string {
+  return product.id.toUpperCase();
+}
+
+function readBool(env: Env, name: string): boolean {
+  const value = env[name]?.trim().toLowerCase();
+  return value === 'true' || value === '1' || value === 'yes';
+}
+
+function readBytes(env: Env, name: string): number | undefined {
+  const raw = env[name]?.trim();
+  if (!raw || !/^\d+$/.test(raw)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return parsed > 0 ? parsed : undefined;
+}
+
+function readRoots(env: Env, names: string[]): string[] {
+  const roots: string[] = [];
+  for (const name of names) {
+    const raw = env[name];
+    if (!raw) {
+      continue;
+    }
+    for (const part of raw.split(delimiter)) {
+      const trimmed = part.trim();
+      if (trimmed) {
+        roots.push(trimmed);
+      }
+    }
+  }
+  return roots;
+}
+
+function canonicalizeRoots(rawRoots: string[], warn: Warn): string[] {
+  const canonical: string[] = [];
+  for (const root of rawRoots) {
+    if (!isAbsolute(root)) {
+      warn(`Ignoring attachment root that is not an absolute path: "${root}"`);
+      continue;
+    }
+    try {
+      const real = realpathSync(root);
+      if (!canonical.includes(real)) {
+        canonical.push(real);
+      }
+    } catch {
+      warn(`Ignoring attachment root that does not exist or cannot be resolved: "${root}"`);
+    }
+  }
+  return canonical;
+}
+
+function resolveSide(args: {
+  enabledFlag: boolean;
+  rawRoots: string[];
+  maxBytes: number;
+  label: string;
+  rootEnvHint: string;
+  warn: Warn;
+}): AttachmentGatewaySide {
+  if (!args.enabledFlag) {
+    return { enabled: false, roots: [], maxBytes: args.maxBytes };
+  }
+  const roots = canonicalizeRoots(args.rawRoots, args.warn);
+  if (roots.length === 0) {
+    args.warn(
+      `${args.label} attachments were enabled but no valid directory is configured ` +
+        `(set ${args.rootEnvHint}); the ${args.label} tool will stay disabled.`,
+    );
+    return { enabled: false, roots: [], maxBytes: args.maxBytes };
+  }
+  return { enabled: true, roots, maxBytes: args.maxBytes };
+}
+
+/**
+ * Reads the attachment gateway configuration for a product from the environment.
+ * Roots are canonicalized once here; a direction is only reported as enabled when
+ * its flag is set and at least one valid root resolves.
+ */
+export function resolveAttachmentGateway(
+  product: ProductDefinition,
+  options?: { env?: Env; warn?: Warn },
+): AttachmentGateway {
+  const env = options?.env ?? process.env;
+  const warn = options?.warn ?? ((message: string) => console.error(`[attachment-gateway] ${message}`));
+  const p = envPrefix(product);
+
+  const exchangeDir = env[`${p}_ATTACHMENTS_DIR`]?.trim();
+  const dirRoots = exchangeDir ? [exchangeDir] : [];
+
+  const upload = resolveSide({
+    enabledFlag: readBool(env, `${p}_ATTACHMENTS_UPLOAD_ENABLED`),
+    rawRoots: [...readRoots(env, [`${p}_ATTACHMENTS_UPLOAD_ROOTS`]), ...dirRoots],
+    maxBytes: readBytes(env, `${p}_ATTACHMENTS_MAX_UPLOAD_BYTES`) ?? DEFAULT_MAX_ATTACHMENT_BYTES,
+    label: 'upload',
+    rootEnvHint: `${p}_ATTACHMENTS_UPLOAD_ROOTS or ${p}_ATTACHMENTS_DIR`,
+    warn,
+  });
+
+  const download = resolveSide({
+    enabledFlag: readBool(env, `${p}_ATTACHMENTS_DOWNLOAD_ENABLED`),
+    rawRoots: [...readRoots(env, [`${p}_ATTACHMENTS_DOWNLOAD_ROOTS`]), ...dirRoots],
+    maxBytes: readBytes(env, `${p}_ATTACHMENTS_MAX_DOWNLOAD_BYTES`) ?? DEFAULT_MAX_ATTACHMENT_BYTES,
+    label: 'download',
+    rootEnvHint: `${p}_ATTACHMENTS_DOWNLOAD_ROOTS or ${p}_ATTACHMENTS_DIR`,
+    warn,
+  });
+
+  return { upload, download };
+}
+
+function normalizeRelative(requested: string): string {
+  if (!requested || !requested.trim()) {
+    throw new Error('A file path is required');
+  }
+  if (isAbsolute(requested)) {
+    throw new Error(`Path must be relative to a configured attachment root, not absolute: "${requested}"`);
+  }
+  const norm = normalize(requested);
+  if (norm === '.' || norm === '..' || norm === '' || norm.startsWith(`..${sep}`) || norm.startsWith('../')) {
+    throw new Error(`Path must stay within the configured attachment root: "${requested}"`);
+  }
+  return norm;
+}
+
+function withinRoot(candidate: string, root: string): boolean {
+  return candidate === root || candidate.startsWith(root + sep);
+}
+
+/**
+ * Canonicalizes the deepest existing ancestor of `target` (resolving symlinked
+ * directories) and re-attaches the not-yet-existing tail. Used to confirm a path
+ * cannot escape a root through a symlinked parent directory.
+ */
+async function canonicalizeDeepestExisting(target: string): Promise<string> {
+  let current = target;
+  while (true) {
+    try {
+      const real = await realpath(current);
+      const tail = relative(current, target);
+      return tail ? join(real, tail) : real;
+    } catch {
+      const parent = dirname(current);
+      if (parent === current) {
+        throw new Error(`Cannot resolve path: "${target}"`);
+      }
+      current = parent;
+    }
+  }
+}
+
+/**
+ * Resolves `requested` (relative) against the allowed roots, returning an absolute
+ * path whose parent directory is canonically inside a root. The final path
+ * component is NOT symlink-resolved, so callers can still detect a symlinked leaf.
+ */
+async function resolveLeafWithinRoots(requested: string, roots: string[]): Promise<string> {
+  const norm = normalizeRelative(requested);
+  for (const root of roots) {
+    const lexical = resolve(root, norm);
+    if (!withinRoot(lexical, root)) {
+      continue;
+    }
+    const parentReal = await canonicalizeDeepestExisting(dirname(lexical));
+    if (withinRoot(parentReal, root)) {
+      return join(parentReal, basename(lexical));
+    }
+  }
+  throw new Error(`Path resolves outside the configured attachment root(s): "${requested}"`);
+}
+
+/**
+ * Resolves and validates a file to upload: it must live inside an allowed upload
+ * root, be a regular file (never a symlink or special file), and be within the
+ * size limit. Returns the absolute path to read.
+ */
+export async function resolveUploadSource(params: {
+  requestedPath: string;
+  side: AttachmentGatewaySide;
+}): Promise<{ absolutePath: string; size: number }> {
+  if (!params.side.enabled) {
+    throw new Error('Attachment upload from the local filesystem is disabled on this server');
+  }
+  const absolutePath = await resolveLeafWithinRoots(params.requestedPath, params.side.roots);
+  const info = await lstat(absolutePath);
+  if (info.isSymbolicLink()) {
+    throw new Error(`Refusing to upload a symlink: "${params.requestedPath}"`);
+  }
+  if (!info.isFile()) {
+    throw new Error(`Refusing to upload a non-regular file: "${params.requestedPath}"`);
+  }
+  if (info.size > params.side.maxBytes) {
+    throw new Error(
+      `File size ${info.size} bytes exceeds the configured upload limit of ${params.side.maxBytes} bytes`,
+    );
+  }
+  return { absolutePath, size: info.size };
+}
+
+/**
+ * Resolves a destination path to save a downloaded attachment into. The file is
+ * placed in the first configured download root; the caller writes with an
+ * exclusive flag so existing files (including symlinks) are never overwritten.
+ */
+export async function resolveDownloadDestination(params: {
+  requestedName: string;
+  side: AttachmentGatewaySide;
+}): Promise<string> {
+  if (!params.side.enabled) {
+    throw new Error('Saving attachments to the local filesystem is disabled on this server');
+  }
+  const safeName = basename(params.requestedName);
+  if (!safeName || safeName === '.' || safeName === '..') {
+    throw new Error(`Invalid attachment file name: "${params.requestedName}"`);
+  }
+  return resolveLeafWithinRoots(safeName, [params.side.roots[0]]);
+}
+
+/** Resolves a path within roots, throwing if it escapes. Exported for verification/tests. */
+export async function assertWithinRoots(requested: string, roots: string[]): Promise<string> {
+  return resolveLeafWithinRoots(requested, roots);
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 export * from './api-error-handler.js'
+export * from './attachment-download.js'
 export * from './config/index.js';
 export { runSetup, runSetupCli } from './setup-cli.js';
 export { describeValidationError } from './setup/describe-error.js';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,6 +3,7 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 export * from './api-error-handler.js'
 export * from './attachment-download.js'
+export * from './attachment-gateway.js'
 export * from './config/index.js';
 export { runSetup, runSetupCli } from './setup-cli.js';
 export { describeValidationError } from './setup/describe-error.js';

--- a/packages/confluence/README.md
+++ b/packages/confluence/README.md
@@ -103,6 +103,37 @@ Available flags: `--host`/`-H`, `--api-base-path`/`-b`, `--token`/`-t`, `--defau
 
    See [Configuration sources](#configuration-sources) for the full precedence chain.
 
+   ### Attachment filesystem access (opt-in)
+
+   By default this server is an API-only client: the attachment tools never read from or write to the local filesystem, and `confluence_uploadAttachment` is **not even registered**. `confluence_downloadAttachment` is always available but can only return file bytes inline (base64/text) — it cannot touch local disk.
+
+   Local filesystem access is opt-in and confined to operator-configured directories that the model cannot choose:
+
+   ```
+   # Enable each direction separately (default: false)
+   CONFLUENCE_ATTACHMENTS_UPLOAD_ENABLED=true
+   CONFLUENCE_ATTACHMENTS_DOWNLOAD_ENABLED=true
+
+   # Allowed roots (os path-separator list). Uploads may only read from these,
+   # downloads may only write into the first configured download root.
+   CONFLUENCE_ATTACHMENTS_UPLOAD_ROOTS=/srv/confluence-exchange/in
+   CONFLUENCE_ATTACHMENTS_DOWNLOAD_ROOTS=/srv/confluence-exchange/out
+
+   # Convenience: a single dedicated exchange directory used as both roots
+   CONFLUENCE_ATTACHMENTS_DIR=/srv/confluence-exchange
+
+   # Hard per-file size limits in bytes (default: 25 MiB)
+   CONFLUENCE_ATTACHMENTS_MAX_UPLOAD_BYTES=26214400
+   CONFLUENCE_ATTACHMENTS_MAX_DOWNLOAD_BYTES=26214400
+   ```
+
+   Guardrails applied when enabled:
+   - A direction only activates when its flag is set **and** at least one root resolves; otherwise the tool stays disabled and a warning is logged.
+   - Roots are canonicalized (realpath) at startup. Requested paths are relative to a root; absolute paths and `..` segments are rejected, and a path that escapes a root through a symlinked directory is refused.
+   - Uploads reject symlinks and non-regular files (FIFOs, devices, directories).
+   - Downloads never overwrite an existing file (including a symlink) — they use an exclusive write.
+   - Both directions enforce the configured hard size limit.
+
    To create a personal access token:
    - In Confluence, select your profile picture at the top right
    - Select **Settings** > **Personal Access Tokens**
@@ -211,12 +242,12 @@ Parameters:
 
 #### 6. confluence_uploadAttachment
 
-Upload a local file as an attachment to a Confluence content (page).
+Upload a local file as an attachment to a Confluence content (page). Only registered when filesystem uploads are enabled (see [Attachment filesystem access](#attachment-filesystem-access-opt-in)).
 
 Parameters:
 - `contentId` (string, required): ID of the content (page) to attach the file to
-- `filePath` (string, required): Absolute local filesystem path of the file to upload
-- `filename` (string, optional): Override for the attachment filename (defaults to the basename of `filePath`)
+- `sourcePath` (string, required): Path to the file to upload, **relative to a server-configured upload directory**. Absolute paths and `..` segments are rejected; symlinks and non-regular files are refused.
+- `filename` (string, optional): Override for the attachment filename (defaults to the basename of `sourcePath`)
 - `comment` (string, optional): Comment describing the attachment
 - `minorEdit` (boolean, optional): If true, no notification email is sent to watchers
 - `hidden` (boolean, optional): If true, no notification email or activity stream entry is generated
@@ -225,12 +256,12 @@ Parameters:
 
 #### 7. confluence_downloadAttachment
 
-Download one or more attachments from a Confluence content (page). Can save to a local path and/or return the file content inline (base64 or text) — useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Jira issue).
+Download one or more attachments from a Confluence content (page). Returns the file content inline (base64 or text) — useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Jira issue). When filesystem downloads are enabled (see [Attachment filesystem access](#attachment-filesystem-access-opt-in)), it can also save into the server-configured download directory.
 
 Parameters:
 - `contentId` (string, required): ID of the content (page) whose attachment(s) to download
 - `filename` (string, optional): Exact filename of a single attachment to download. If omitted, all attachments on the content are downloaded.
-- `saveDir` (string, optional): Absolute local directory to save the attachment(s) into. The attachment filename is used as the file name. Preferred when downloading multiple files.
-- `savePath` (string, optional): Absolute local file path to save a single attachment to. Overrides `saveDir`.
-- `returnContent` (`none` | `base64` | `text`, optional): Whether to embed the file bytes in the response. Defaults to `none`. Combine with `saveDir`/`savePath` to also save to disk.
-- `maxInlineBytes` (number, optional): Maximum bytes to embed inline when `returnContent` is `base64`/`text`. Larger files are saved (if a path is given) but not embedded. Defaults to 1 MiB.
+- `returnContent` (`none` | `base64` | `text`, optional): Whether to embed the file bytes in the response. Defaults to `none`.
+- `maxInlineBytes` (number, optional): Maximum bytes to embed inline when `returnContent` is `base64`/`text`. Larger files are omitted from the inline content. Defaults to 1 MiB.
+- `save` (boolean, optional): Save the attachment(s) into the server-configured download directory. Requires filesystem downloads to be enabled; existing files are never overwritten. *(Only available when downloads are enabled.)*
+- `saveName` (string, optional): File name (no directories) to use when saving a single attachment; defaults to the attachment's own name. *(Only available when downloads are enabled.)*

--- a/packages/confluence/README.md
+++ b/packages/confluence/README.md
@@ -208,3 +208,29 @@ Parameters:
 - `start` (number, optional): Start index for pagination
 - `expand` (string, optional): Comma-separated list of properties to expand
 - `excerpt` (`none` | `highlight`, optional): Excerpt mode for search results. Defaults to `none`.
+
+#### 6. confluence_uploadAttachment
+
+Upload a local file as an attachment to a Confluence content (page).
+
+Parameters:
+- `contentId` (string, required): ID of the content (page) to attach the file to
+- `filePath` (string, required): Absolute local filesystem path of the file to upload
+- `filename` (string, optional): Override for the attachment filename (defaults to the basename of `filePath`)
+- `comment` (string, optional): Comment describing the attachment
+- `minorEdit` (boolean, optional): If true, no notification email is sent to watchers
+- `hidden` (boolean, optional): If true, no notification email or activity stream entry is generated
+- `allowDuplicated` (boolean, optional): Allow upload even if an attachment with the same filename already exists
+- `versionIfExists` (boolean, optional): If true and an attachment with the same filename already exists, upload as a new version instead of failing
+
+#### 7. confluence_downloadAttachment
+
+Download one or more attachments from a Confluence content (page). Can save to a local path and/or return the file content inline (base64 or text) — useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Jira issue).
+
+Parameters:
+- `contentId` (string, required): ID of the content (page) whose attachment(s) to download
+- `filename` (string, optional): Exact filename of a single attachment to download. If omitted, all attachments on the content are downloaded.
+- `saveDir` (string, optional): Absolute local directory to save the attachment(s) into. The attachment filename is used as the file name. Preferred when downloading multiple files.
+- `savePath` (string, optional): Absolute local file path to save a single attachment to. Overrides `saveDir`.
+- `returnContent` (`none` | `base64` | `text`, optional): Whether to embed the file bytes in the response. Defaults to `none`. Combine with `saveDir`/`savePath` to also save to disk.
+- `maxInlineBytes` (number, optional): Maximum bytes to embed inline when `returnContent` is `base64`/`text`. Larger files are saved (if a path is given) but not embedded. Defaults to 1 MiB.

--- a/packages/confluence/src/__tests__/confluence-download.test.ts
+++ b/packages/confluence/src/__tests__/confluence-download.test.ts
@@ -1,0 +1,78 @@
+import { ConfluenceService } from '../confluence-service.js';
+import { AttachmentsService } from '../confluence-client/index.js';
+
+jest.mock('../confluence-client/index.js', () => ({
+  AttachmentsService: {
+    getAttachments: jest.fn(),
+  },
+  ContentResourceService: {},
+  SearchService: {},
+  UserService: {},
+  OpenAPI: { BASE: '', TOKEN: '', VERSION: '' },
+}));
+
+function mockFetchText(text: string) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: { get: () => 'text/plain' },
+    arrayBuffer: async () => Buffer.from(text),
+  }) as unknown as typeof fetch;
+}
+
+describe('ConfluenceService.downloadAttachmentFromContent', () => {
+  let service: ConfluenceService;
+
+  beforeEach(() => {
+    service = new ConfluenceService('test-host', 'test-token');
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('builds an absolute download URL from the relative _links.download and returns content', async () => {
+    (AttachmentsService.getAttachments as jest.Mock).mockResolvedValue({
+      results: [
+        { title: 'doc.txt', metadata: { mediaType: 'text/plain' }, _links: { download: '/download/attachments/123/doc.txt?version=1' } },
+      ],
+    });
+    mockFetchText('file body');
+
+    const result = await service.downloadAttachmentFromContent('123', 'doc.txt', { returnContent: 'text' });
+
+    expect(AttachmentsService.getAttachments).toHaveBeenCalledWith('123', undefined, 'doc.txt');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://test-host/download/attachments/123/doc.txt?version=1',
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer test-token' }) }),
+    );
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({ contentId: '123', count: 1 });
+    expect(result.data!.attachments[0]).toMatchObject({ filename: 'doc.txt', content: 'file body', mediaType: 'text/plain' });
+  });
+
+  it('downloads all attachments when no filename is given', async () => {
+    (AttachmentsService.getAttachments as jest.Mock).mockResolvedValue({
+      results: [
+        { title: 'a.txt', _links: { download: '/download/attachments/123/a.txt' } },
+        { title: 'b.txt', _links: { download: '/download/attachments/123/b.txt' } },
+      ],
+    });
+    mockFetchText('x');
+
+    const result = await service.downloadAttachmentFromContent('123');
+
+    expect(result.success).toBe(true);
+    expect(result.data!.count).toBe(2);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns a failure when the content has no matching attachment', async () => {
+    (AttachmentsService.getAttachments as jest.Mock).mockResolvedValue({ results: [] });
+
+    const result = await service.downloadAttachmentFromContent('123', 'missing.txt');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('No attachment named "missing.txt"');
+  });
+});

--- a/packages/confluence/src/__tests__/confluence-download.test.ts
+++ b/packages/confluence/src/__tests__/confluence-download.test.ts
@@ -1,5 +1,8 @@
+import type { AttachmentGatewaySide } from '@atlassian-dc-mcp/common';
 import { ConfluenceService } from '../confluence-service.js';
 import { AttachmentsService } from '../confluence-client/index.js';
+
+const DISABLED_DOWNLOAD: AttachmentGatewaySide = { enabled: false, roots: [], maxBytes: 25 * 1024 * 1024 };
 
 jest.mock('../confluence-client/index.js', () => ({
   AttachmentsService: {
@@ -39,7 +42,7 @@ describe('ConfluenceService.downloadAttachmentFromContent', () => {
     });
     mockFetchText('file body');
 
-    const result = await service.downloadAttachmentFromContent('123', 'doc.txt', { returnContent: 'text' });
+    const result = await service.downloadAttachmentFromContent({ contentId: '123', filename: 'doc.txt', returnContent: 'text', downloadSide: DISABLED_DOWNLOAD });
 
     expect(AttachmentsService.getAttachments).toHaveBeenCalledWith('123', undefined, 'doc.txt');
     expect(global.fetch).toHaveBeenCalledWith(
@@ -60,7 +63,7 @@ describe('ConfluenceService.downloadAttachmentFromContent', () => {
     });
     mockFetchText('x');
 
-    const result = await service.downloadAttachmentFromContent('123');
+    const result = await service.downloadAttachmentFromContent({ contentId: '123', downloadSide: DISABLED_DOWNLOAD });
 
     expect(result.success).toBe(true);
     expect(result.data!.count).toBe(2);
@@ -70,9 +73,17 @@ describe('ConfluenceService.downloadAttachmentFromContent', () => {
   it('returns a failure when the content has no matching attachment', async () => {
     (AttachmentsService.getAttachments as jest.Mock).mockResolvedValue({ results: [] });
 
-    const result = await service.downloadAttachmentFromContent('123', 'missing.txt');
+    const result = await service.downloadAttachmentFromContent({ contentId: '123', filename: 'missing.txt', downloadSide: DISABLED_DOWNLOAD });
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('No attachment named "missing.txt"');
+  });
+
+  it('refuses to save to disk when downloads are disabled', async () => {
+    const result = await service.downloadAttachmentFromContent({ contentId: '123', filename: 'doc.txt', save: true, downloadSide: DISABLED_DOWNLOAD });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('disabled');
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/confluence/src/__tests__/confluence-upload.test.ts
+++ b/packages/confluence/src/__tests__/confluence-upload.test.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AttachmentGatewaySide } from '@atlassian-dc-mcp/common';
+import { ConfluenceService } from '../confluence-service.js';
+import { AttachmentsService } from '../confluence-client/index.js';
+
+jest.mock('../confluence-client/index.js', () => ({
+  AttachmentsService: {
+    getAttachments: jest.fn(),
+    createAttachments: jest.fn(),
+    updateData: jest.fn(),
+  },
+  ContentResourceService: {},
+  SearchService: {},
+  UserService: {},
+  OpenAPI: { BASE: '', TOKEN: '', VERSION: '', HEADERS: undefined },
+}));
+
+describe('ConfluenceService.uploadAttachment', () => {
+  let service: ConfluenceService;
+  let root: string;
+  const uploadSide = (): AttachmentGatewaySide => ({ enabled: true, roots: [fs.realpathSync(root)], maxBytes: 1024 });
+
+  beforeEach(() => {
+    service = new ConfluenceService('test-host', 'test-token');
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mcp-cup-'));
+    jest.clearAllMocks();
+    (AttachmentsService.createAttachments as jest.Mock).mockResolvedValue({ results: [{ id: '1', title: 'a.txt' }] });
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  it('uploads a file resolved within the upload root', async () => {
+    fs.writeFileSync(path.join(root, 'a.txt'), 'hello');
+
+    const result = await service.uploadAttachment('42', 'a.txt', uploadSide());
+
+    expect(result.success).toBe(true);
+    expect(AttachmentsService.createAttachments).toHaveBeenCalledTimes(1);
+    const formData = (AttachmentsService.createAttachments as jest.Mock).mock.calls[0][4];
+    expect(formData.file.name).toBe('a.txt');
+  });
+
+  it('rejects an absolute path outside the root', async () => {
+    const result = await service.uploadAttachment('42', '/etc/passwd', uploadSide());
+    expect(result.success).toBe(false);
+    expect(AttachmentsService.createAttachments).not.toHaveBeenCalled();
+  });
+
+  it('rejects a symlink inside the root', async () => {
+    const target = path.join(root, 'real.txt');
+    fs.writeFileSync(target, 'secret');
+    fs.symlinkSync(target, path.join(root, 'link.txt'));
+
+    const result = await service.uploadAttachment('42', 'link.txt', uploadSide());
+    expect(result.success).toBe(false);
+    expect(AttachmentsService.createAttachments).not.toHaveBeenCalled();
+  });
+
+  it('rejects a file over the size limit', async () => {
+    fs.writeFileSync(path.join(root, 'big.txt'), 'x'.repeat(2048));
+
+    const result = await service.uploadAttachment('42', 'big.txt', uploadSide());
+    expect(result.success).toBe(false);
+    expect(AttachmentsService.createAttachments).not.toHaveBeenCalled();
+  });
+});

--- a/packages/confluence/src/confluence-service.ts
+++ b/packages/confluence/src/confluence-service.ts
@@ -147,17 +147,29 @@ export class ConfluenceService {
     minorEdit?: boolean,
     hidden?: boolean,
     allowDuplicated?: boolean,
+    versionIfExists?: boolean,
   ) {
     const buffer = await readFile(filePath);
     const name = filename || basename(filePath);
     const file = new File([buffer], name);
-    // MockAttachmentRequest types file as string, but getFormData in request.ts handles Blob/File via isBlob()
-    const formData = { file, comment, minorEdit, hidden } as any;
     // X-Atlassian-Token: nocheck is required for multipart attachment POSTs (XSRF bypass).
     // Set it only for the duration of this call; restore afterwards.
     const prevHeaders = OpenAPI.HEADERS;
     OpenAPI.HEADERS = { 'X-Atlassian-Token': 'nocheck' };
     try {
+      if (versionIfExists) {
+        const existing = await AttachmentsService.getAttachments(contentId, undefined, name);
+        const existingId = (existing as any)?.results?.[0]?.id;
+        if (existingId) {
+          // MockAttachmentRequest types file as string, but getFormData handles Blob/File via isBlob()
+          return await handleApiOperation(
+            () => AttachmentsService.updateData(existingId, contentId, { file } as any),
+            'Error uploading attachment version',
+          );
+        }
+      }
+      // MockAttachmentRequest types file as string, but getFormData in request.ts handles Blob/File via isBlob()
+      const formData = { file, comment, minorEdit, hidden } as any;
       return await handleApiOperation(
         () => AttachmentsService.createAttachments(
           contentId,
@@ -256,6 +268,7 @@ export const confluenceToolSchemas = {
     comment: z.string().optional().describe("Optional comment describing the attachment"),
     minorEdit: z.boolean().optional().describe("If true, no notification email is sent to watchers"),
     hidden: z.boolean().optional().describe("If true, no notification email or activity stream entry is generated"),
-    allowDuplicated: z.boolean().optional().describe("Allow upload even if an attachment with the same filename already exists")
+    allowDuplicated: z.boolean().optional().describe("Allow upload even if an attachment with the same filename already exists"),
+    versionIfExists: z.boolean().optional().describe("If true and an attachment with the same filename already exists, upload as a new version instead of failing")
   }
 };

--- a/packages/confluence/src/confluence-service.ts
+++ b/packages/confluence/src/confluence-service.ts
@@ -1,5 +1,8 @@
+import { File } from 'node:buffer';
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
 import { z } from 'zod';
-import { ContentResourceService, OpenAPI, SearchService, UserService } from './confluence-client/index.js';
+import { AttachmentsService, ContentResourceService, OpenAPI, SearchService, UserService } from './confluence-client/index.js';
 import { handleApiOperation, resolveOpenApiBase } from '@atlassian-dc-mcp/common';
 import { CONFLUENCE_PRODUCT, getDefaultPageSize, getMissingConfig } from './config.js';
 import { ConfluenceBodyMode, shapeConfluenceContent } from './confluence-response-mapper.js';
@@ -127,6 +130,50 @@ export class ConfluenceService {
   }
 
   /**
+   * Upload a file as an attachment to a Confluence content entity
+   * @param contentId The ID of the content the attachment will be attached to
+   * @param filePath Local filesystem path to the file to upload
+   * @param filename Optional override for the attachment filename (defaults to basename of filePath)
+   * @param comment Optional comment describing the attachment
+   * @param minorEdit If true, no notification email will be generated
+   * @param hidden If true, no notification email or activity stream entry will be generated
+   * @param allowDuplicated Allow upload even if an attachment with the same filename exists
+   */
+  async uploadAttachment(
+    contentId: string,
+    filePath: string,
+    filename?: string,
+    comment?: string,
+    minorEdit?: boolean,
+    hidden?: boolean,
+    allowDuplicated?: boolean,
+  ) {
+    const buffer = await readFile(filePath);
+    const name = filename || basename(filePath);
+    const file = new File([buffer], name);
+    // MockAttachmentRequest types file as string, but getFormData in request.ts handles Blob/File via isBlob()
+    const formData = { file, comment, minorEdit, hidden } as any;
+    // X-Atlassian-Token: nocheck is required for multipart attachment POSTs (XSRF bypass).
+    // Set it only for the duration of this call; restore afterwards.
+    const prevHeaders = OpenAPI.HEADERS;
+    OpenAPI.HEADERS = { 'X-Atlassian-Token': 'nocheck' };
+    try {
+      return await handleApiOperation(
+        () => AttachmentsService.createAttachments(
+          contentId,
+          undefined,
+          allowDuplicated ? 'true' : undefined,
+          undefined,
+          formData,
+        ),
+        'Error uploading attachment',
+      );
+    } finally {
+      OpenAPI.HEADERS = prevHeaders;
+    }
+  }
+
+  /**
    * Search for spaces by text
    * @param searchText Text to search for in space names or descriptions
    * @param limit Maximum number of results to return
@@ -201,5 +248,14 @@ export const confluenceToolSchemas = {
     start: z.number().optional().describe("Start index for pagination"),
     expand: z.string().optional().describe("Comma-separated list of properties to expand"),
     excerpt: z.enum(['none', 'highlight']).optional().describe("Excerpt mode for search results. Defaults to none.")
+  },
+  uploadAttachment: {
+    contentId: z.string().describe("ID of the Confluence content (page) to attach the file to"),
+    filePath: z.string().describe("Absolute local filesystem path of the file to upload"),
+    filename: z.string().optional().describe("Override for the attachment filename (defaults to the basename of filePath)"),
+    comment: z.string().optional().describe("Optional comment describing the attachment"),
+    minorEdit: z.boolean().optional().describe("If true, no notification email is sent to watchers"),
+    hidden: z.boolean().optional().describe("If true, no notification email or activity stream entry is generated"),
+    allowDuplicated: z.boolean().optional().describe("Allow upload even if an attachment with the same filename already exists")
   }
 };

--- a/packages/confluence/src/confluence-service.ts
+++ b/packages/confluence/src/confluence-service.ts
@@ -3,7 +3,15 @@ import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { z } from 'zod';
 import { AttachmentsService, ContentResourceService, OpenAPI, SearchService, UserService } from './confluence-client/index.js';
-import { downloadAttachment, handleApiOperation, resolveOpenApiBase, type AttachmentDownloadOptions } from '@atlassian-dc-mcp/common';
+import {
+  downloadAttachment,
+  handleApiOperation,
+  resolveDownloadDestination,
+  resolveOpenApiBase,
+  resolveUploadSource,
+  type AttachmentContentEncoding,
+  type AttachmentGatewaySide,
+} from '@atlassian-dc-mcp/common';
 import { CONFLUENCE_PRODUCT, getDefaultPageSize, getMissingConfig } from './config.js';
 import { ConfluenceBodyMode, shapeConfluenceContent } from './confluence-response-mapper.js';
 
@@ -149,8 +157,9 @@ export class ConfluenceService {
   /**
    * Upload a file as an attachment to a Confluence content entity
    * @param contentId The ID of the content the attachment will be attached to
-   * @param filePath Local filesystem path to the file to upload
-   * @param filename Optional override for the attachment filename (defaults to basename of filePath)
+   * @param sourcePath Path to the file to upload, relative to a server-configured upload directory
+   * @param uploadSide Resolved upload gateway (roots, size limit, enabled flag)
+   * @param filename Optional override for the attachment filename (defaults to basename of sourcePath)
    * @param comment Optional comment describing the attachment
    * @param minorEdit If true, no notification email will be generated
    * @param hidden If true, no notification email or activity stream entry will be generated
@@ -158,7 +167,8 @@ export class ConfluenceService {
    */
   async uploadAttachment(
     contentId: string,
-    filePath: string,
+    sourcePath: string,
+    uploadSide: AttachmentGatewaySide,
     filename?: string,
     comment?: string,
     minorEdit?: boolean,
@@ -166,85 +176,107 @@ export class ConfluenceService {
     allowDuplicated?: boolean,
     versionIfExists?: boolean,
   ) {
-    const buffer = await readFile(filePath);
-    const name = filename || basename(filePath);
-    const file = new File([buffer], name);
-    // X-Atlassian-Token: nocheck is required for multipart attachment POSTs (XSRF bypass).
-    // Set it only for the duration of this call; restore afterwards.
-    const prevHeaders = OpenAPI.HEADERS;
-    OpenAPI.HEADERS = { 'X-Atlassian-Token': 'nocheck' };
-    try {
-      if (versionIfExists) {
-        const existing = await AttachmentsService.getAttachments(contentId, undefined, name);
-        const existingId = (existing as any)?.results?.[0]?.id;
-        if (existingId) {
-          // MockAttachmentRequest types file as string, but getFormData handles Blob/File via isBlob()
-          return await handleApiOperation(
-            () => AttachmentsService.updateData(existingId, contentId, { file } as any),
-            'Error uploading attachment version',
-          );
+    return handleApiOperation(async () => {
+      const { absolutePath } = await resolveUploadSource({ requestedPath: sourcePath, side: uploadSide });
+      const buffer = await readFile(absolutePath);
+      const name = filename || basename(absolutePath);
+      const file = new File([buffer], name);
+      // X-Atlassian-Token: nocheck is required for multipart attachment POSTs (XSRF bypass).
+      // Set it only for the duration of this call; restore afterwards.
+      const prevHeaders = OpenAPI.HEADERS;
+      OpenAPI.HEADERS = { 'X-Atlassian-Token': 'nocheck' };
+      try {
+        if (versionIfExists) {
+          const existing = await AttachmentsService.getAttachments(contentId, undefined, name);
+          const existingId = (existing as any)?.results?.[0]?.id;
+          if (existingId) {
+            // MockAttachmentRequest types file as string, but getFormData handles Blob/File via isBlob()
+            return await AttachmentsService.updateData(existingId, contentId, { file } as any);
+          }
         }
-      }
-      // MockAttachmentRequest types file as string, but getFormData in request.ts handles Blob/File via isBlob()
-      const formData = { file, comment, minorEdit, hidden } as any;
-      return await handleApiOperation(
-        () => AttachmentsService.createAttachments(
+        // MockAttachmentRequest types file as string, but getFormData in request.ts handles Blob/File via isBlob()
+        const formData = { file, comment, minorEdit, hidden } as any;
+        return await AttachmentsService.createAttachments(
           contentId,
           undefined,
           allowDuplicated ? 'true' : undefined,
           undefined,
           formData,
-        ),
-        'Error uploading attachment',
-      );
-    } finally {
-      OpenAPI.HEADERS = prevHeaders;
-    }
+        );
+      } finally {
+        OpenAPI.HEADERS = prevHeaders;
+      }
+    }, 'Error uploading attachment');
   }
 
   /**
    * Download one or more attachments from a Confluence content entity.
-   * @param contentId The ID of the content the attachment(s) are on
-   * @param filename If provided, download only the attachment with this exact filename; otherwise download all attachments on the content
-   * @param options Save-to-disk and inline-content options (see AttachmentDownloadOptions)
+   * @param params.contentId The ID of the content the attachment(s) are on
+   * @param params.filename If provided, download only the attachment with this exact filename; otherwise download all attachments on the content
+   * @param params.save Whether to write the attachment(s) to the operator-configured download directory
+   * @param params.saveName Optional file name (basename only) when saving a single attachment
+   * @param params.returnContent Whether/how to embed the bytes inline in the response
+   * @param params.maxInlineBytes Inline embedding cap
+   * @param params.downloadSide Resolved download gateway (roots, size limit, enabled flag)
    */
-  async downloadAttachmentFromContent(
-    contentId: string,
-    filename?: string,
-    options?: AttachmentDownloadOptions,
-  ) {
+  async downloadAttachmentFromContent(params: {
+    contentId: string;
+    filename?: string;
+    save?: boolean;
+    saveName?: string;
+    returnContent?: AttachmentContentEncoding;
+    maxInlineBytes?: number;
+    downloadSide: AttachmentGatewaySide;
+  }) {
     return handleApiOperation(async () => {
-      const list = await AttachmentsService.getAttachments(contentId, undefined, filename);
+      if (params.save && !params.downloadSide.enabled) {
+        throw new Error(
+          'Saving attachments to disk is disabled on this server. Enable it with ' +
+            'CONFLUENCE_ATTACHMENTS_DOWNLOAD_ENABLED and configure a download directory.',
+        );
+      }
+      const list = await AttachmentsService.getAttachments(params.contentId, undefined, params.filename);
       const results = ((list as any)?.results ?? []) as Array<any>;
       if (results.length === 0) {
         throw new Error(
-          filename
-            ? `No attachment named "${filename}" found on content ${contentId}`
-            : `No attachments found on content ${contentId}`,
+          params.filename
+            ? `No attachment named "${params.filename}" found on content ${params.contentId}`
+            : `No attachments found on content ${params.contentId}`,
         );
       }
 
-      const targets = filename ? [results[0]] : results;
+      const targets = params.filename ? [results[0]] : results;
+      const multiple = targets.length > 1;
       const attachments = [];
       for (const attachment of targets) {
         const downloadLink = attachment?._links?.download;
         if (!downloadLink) {
-          throw new Error(`Attachment "${attachment?.title ?? filename}" has no download link`);
+          throw new Error(`Attachment "${attachment?.title ?? params.filename}" has no download link`);
         }
-        const name = attachment?.title ?? filename ?? 'attachment';
+        const name = attachment?.title ?? params.filename ?? 'attachment';
         const mediaType = attachment?.metadata?.mediaType ?? attachment?.extensions?.mediaType;
+        let destination: string | undefined;
+        if (params.save) {
+          const requestedName = multiple ? name : params.saveName ?? name;
+          destination = await resolveDownloadDestination({ requestedName, side: params.downloadSide });
+        }
         attachments.push(
           await downloadAttachment({
             url: this.buildDownloadUrl(downloadLink),
             token: this.tokenProvider,
             filename: name,
             mediaType,
-            options,
+            options: {
+              destination,
+              returnContent: params.returnContent,
+              maxInlineBytes: params.maxInlineBytes,
+              maxDownloadBytes: params.downloadSide.maxBytes,
+            },
           }),
         );
       }
 
-      return { contentId, count: attachments.length, attachments };
+      return { contentId: params.contentId, count: attachments.length, attachments };
     }, 'Error downloading attachment');
   }
 
@@ -326,8 +358,8 @@ export const confluenceToolSchemas = {
   },
   uploadAttachment: {
     contentId: z.string().describe("ID of the Confluence content (page) to attach the file to"),
-    filePath: z.string().describe("Absolute local filesystem path of the file to upload"),
-    filename: z.string().optional().describe("Override for the attachment filename (defaults to the basename of filePath)"),
+    sourcePath: z.string().describe("Path to the file to upload, relative to a server-configured attachment upload directory. Absolute paths and '..' segments are rejected; symlinks and non-regular files are refused."),
+    filename: z.string().optional().describe("Override for the attachment filename (defaults to the basename of sourcePath)"),
     comment: z.string().optional().describe("Optional comment describing the attachment"),
     minorEdit: z.boolean().optional().describe("If true, no notification email is sent to watchers"),
     hidden: z.boolean().optional().describe("If true, no notification email or activity stream entry is generated"),
@@ -337,9 +369,11 @@ export const confluenceToolSchemas = {
   downloadAttachment: {
     contentId: z.string().describe("ID of the Confluence content (page) whose attachment(s) to download"),
     filename: z.string().optional().describe("Exact filename of a single attachment to download. If omitted, all attachments on the content are downloaded."),
-    saveDir: z.string().optional().describe("Absolute local directory to save the attachment(s) into. The attachment filename is used as the file name. Preferred when downloading multiple files."),
-    savePath: z.string().optional().describe("Absolute local file path to save a single attachment to. Overrides saveDir. Only meaningful when downloading a single attachment."),
-    returnContent: z.enum(['none', 'base64', 'text']).optional().describe("Whether to embed the file bytes in the response: 'none' (default), 'base64' for binary, or 'text' for UTF-8 text. Combine with saveDir/savePath to also save to disk."),
-    maxInlineBytes: z.number().optional().describe("Maximum bytes to embed inline when returnContent is base64/text. Larger files are saved (if a path is given) but not embedded. Defaults to 1 MiB.")
+    returnContent: z.enum(['none', 'base64', 'text']).optional().describe("Whether to embed the file bytes in the response: 'none' (default), 'base64' for binary, or 'text' for UTF-8 text."),
+    maxInlineBytes: z.number().optional().describe("Maximum bytes to embed inline when returnContent is base64/text. Larger files are omitted from the inline content. Defaults to 1 MiB.")
+  },
+  downloadAttachmentSaveFields: {
+    save: z.boolean().optional().describe("Save the attachment(s) into the server-configured download directory. Requires disk downloads to be enabled on the server."),
+    saveName: z.string().optional().describe("Optional file name (no directories) to use when saving a single attachment; defaults to the attachment's own name. Existing files are never overwritten.")
   }
 };

--- a/packages/confluence/src/confluence-service.ts
+++ b/packages/confluence/src/confluence-service.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { z } from 'zod';
 import { AttachmentsService, ContentResourceService, OpenAPI, SearchService, UserService } from './confluence-client/index.js';
-import { handleApiOperation, resolveOpenApiBase } from '@atlassian-dc-mcp/common';
+import { downloadAttachment, handleApiOperation, resolveOpenApiBase, type AttachmentDownloadOptions } from '@atlassian-dc-mcp/common';
 import { CONFLUENCE_PRODUCT, getDefaultPageSize, getMissingConfig } from './config.js';
 import { ConfluenceBodyMode, shapeConfluenceContent } from './confluence-response-mapper.js';
 
@@ -48,6 +48,8 @@ function resolveToken(token: string | (() => string | undefined), missingTokenMe
 
 export class ConfluenceService {
   private readonly getPageSize: () => number;
+  private readonly baseUrl: string;
+  private readonly tokenProvider: string | (() => string | undefined);
 
   constructor(
     host: string | undefined,
@@ -55,15 +57,30 @@ export class ConfluenceService {
     apiBasePath?: string,
     getPageSize: () => number = getDefaultPageSize,
   ) {
-    OpenAPI.BASE = resolveOpenApiBase({
+    const base = resolveOpenApiBase({
       host,
       apiBasePath,
       defaultBasePath: CONFLUENCE_PRODUCT.defaultApiBasePath ?? '',
       strippableSuffixes: CONFLUENCE_PRODUCT.apiBasePathStrippableSuffixes,
     });
+    OpenAPI.BASE = base;
     OpenAPI.TOKEN = resolveToken(token, 'Missing required environment variable: CONFLUENCE_API_TOKEN');
     OpenAPI.VERSION = '1.0';
+    this.baseUrl = base;
+    this.tokenProvider = token;
     this.getPageSize = getPageSize;
+  }
+
+  /**
+   * Builds an absolute download URL from a Confluence attachment `_links.download`
+   * value, which is a path relative to the site base (context path included).
+   */
+  private buildDownloadUrl(downloadLink: string): string {
+    if (/^https?:\/\//i.test(downloadLink)) {
+      return downloadLink;
+    }
+    const base = this.baseUrl.replace(/\/$/, '');
+    return `${base}${downloadLink.startsWith('/') ? '' : '/'}${downloadLink}`;
   }
   /**
    * Get a Confluence page by ID
@@ -186,6 +203,52 @@ export class ConfluenceService {
   }
 
   /**
+   * Download one or more attachments from a Confluence content entity.
+   * @param contentId The ID of the content the attachment(s) are on
+   * @param filename If provided, download only the attachment with this exact filename; otherwise download all attachments on the content
+   * @param options Save-to-disk and inline-content options (see AttachmentDownloadOptions)
+   */
+  async downloadAttachmentFromContent(
+    contentId: string,
+    filename?: string,
+    options?: AttachmentDownloadOptions,
+  ) {
+    return handleApiOperation(async () => {
+      const list = await AttachmentsService.getAttachments(contentId, undefined, filename);
+      const results = ((list as any)?.results ?? []) as Array<any>;
+      if (results.length === 0) {
+        throw new Error(
+          filename
+            ? `No attachment named "${filename}" found on content ${contentId}`
+            : `No attachments found on content ${contentId}`,
+        );
+      }
+
+      const targets = filename ? [results[0]] : results;
+      const attachments = [];
+      for (const attachment of targets) {
+        const downloadLink = attachment?._links?.download;
+        if (!downloadLink) {
+          throw new Error(`Attachment "${attachment?.title ?? filename}" has no download link`);
+        }
+        const name = attachment?.title ?? filename ?? 'attachment';
+        const mediaType = attachment?.metadata?.mediaType ?? attachment?.extensions?.mediaType;
+        attachments.push(
+          await downloadAttachment({
+            url: this.buildDownloadUrl(downloadLink),
+            token: this.tokenProvider,
+            filename: name,
+            mediaType,
+            options,
+          }),
+        );
+      }
+
+      return { contentId, count: attachments.length, attachments };
+    }, 'Error downloading attachment');
+  }
+
+  /**
    * Search for spaces by text
    * @param searchText Text to search for in space names or descriptions
    * @param limit Maximum number of results to return
@@ -270,5 +333,13 @@ export const confluenceToolSchemas = {
     hidden: z.boolean().optional().describe("If true, no notification email or activity stream entry is generated"),
     allowDuplicated: z.boolean().optional().describe("Allow upload even if an attachment with the same filename already exists"),
     versionIfExists: z.boolean().optional().describe("If true and an attachment with the same filename already exists, upload as a new version instead of failing")
+  },
+  downloadAttachment: {
+    contentId: z.string().describe("ID of the Confluence content (page) whose attachment(s) to download"),
+    filename: z.string().optional().describe("Exact filename of a single attachment to download. If omitted, all attachments on the content are downloaded."),
+    saveDir: z.string().optional().describe("Absolute local directory to save the attachment(s) into. The attachment filename is used as the file name. Preferred when downloading multiple files."),
+    savePath: z.string().optional().describe("Absolute local file path to save a single attachment to. Overrides saveDir. Only meaningful when downloading a single attachment."),
+    returnContent: z.enum(['none', 'base64', 'text']).optional().describe("Whether to embed the file bytes in the response: 'none' (default), 'base64' for binary, or 'text' for UTF-8 text. Combine with saveDir/savePath to also save to disk."),
+    maxInlineBytes: z.number().optional().describe("Maximum bytes to embed inline when returnContent is base64/text. Larger files are saved (if a path is given) but not embedded. Defaults to 1 MiB.")
   }
 };

--- a/packages/confluence/src/index.ts
+++ b/packages/confluence/src/index.ts
@@ -141,6 +141,24 @@ server.tool(
   }
 );
 
+server.tool(
+  "confluence_uploadAttachment",
+  "Upload a local file as an attachment to a Confluence content (page)",
+  confluenceToolSchemas.uploadAttachment,
+  async ({ contentId, filePath, filename, comment, minorEdit, hidden, allowDuplicated }) => {
+    const result = await confluenceService.uploadAttachment(
+      contentId,
+      filePath,
+      filename,
+      comment,
+      minorEdit,
+      hidden,
+      allowDuplicated,
+    );
+    return formatToolResponse(result);
+  }
+);
+
 server.tool('confluence_searchSpace',
   `Search for spaces in ${confluenceInstanceType}`,
   confluenceToolSchemas.searchSpaces,

--- a/packages/confluence/src/index.ts
+++ b/packages/confluence/src/index.ts
@@ -145,7 +145,7 @@ server.tool(
   "confluence_uploadAttachment",
   "Upload a local file as an attachment to a Confluence content (page)",
   confluenceToolSchemas.uploadAttachment,
-  async ({ contentId, filePath, filename, comment, minorEdit, hidden, allowDuplicated }) => {
+  async ({ contentId, filePath, filename, comment, minorEdit, hidden, allowDuplicated, versionIfExists }) => {
     const result = await confluenceService.uploadAttachment(
       contentId,
       filePath,
@@ -154,6 +154,7 @@ server.tool(
       minorEdit,
       hidden,
       allowDuplicated,
+      versionIfExists,
     );
     return formatToolResponse(result);
   }

--- a/packages/confluence/src/index.ts
+++ b/packages/confluence/src/index.ts
@@ -160,6 +160,21 @@ server.tool(
   }
 );
 
+server.tool(
+  "confluence_downloadAttachment",
+  `Download one or more attachments from a Confluence content (page) in the ${confluenceInstanceType}. Can save to a local path and/or return the file content inline (base64 or text). Useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Jira issue).`,
+  confluenceToolSchemas.downloadAttachment,
+  async ({ contentId, filename, saveDir, savePath, returnContent, maxInlineBytes }) => {
+    const result = await confluenceService.downloadAttachmentFromContent(contentId, filename, {
+      saveDir,
+      savePath,
+      returnContent,
+      maxInlineBytes,
+    });
+    return formatToolResponse(result);
+  }
+);
+
 server.tool('confluence_searchSpace',
   `Search for spaces in ${confluenceInstanceType}`,
   confluenceToolSchemas.searchSpaces,

--- a/packages/confluence/src/index.ts
+++ b/packages/confluence/src/index.ts
@@ -1,7 +1,7 @@
-import { connectServer, createMcpServer, formatToolResponse, initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
+import { connectServer, createMcpServer, formatToolResponse, initializeRuntimeConfig, resolveAttachmentGateway } from '@atlassian-dc-mcp/common';
 import { ConfluenceService, ConfluenceContent, confluenceToolSchemas } from './confluence-service.js';
 import { shapeConfluenceMutationAck } from './confluence-response-mapper.js';
-import { getConfluenceRuntimeConfig, getDefaultPageSize } from './config.js';
+import { CONFLUENCE_PRODUCT, getConfluenceRuntimeConfig, getDefaultPageSize } from './config.js';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
@@ -141,35 +141,54 @@ server.tool(
   }
 );
 
-server.tool(
-  "confluence_uploadAttachment",
-  "Upload a local file as an attachment to a Confluence content (page)",
-  confluenceToolSchemas.uploadAttachment,
-  async ({ contentId, filePath, filename, comment, minorEdit, hidden, allowDuplicated, versionIfExists }) => {
-    const result = await confluenceService.uploadAttachment(
-      contentId,
-      filePath,
-      filename,
-      comment,
-      minorEdit,
-      hidden,
-      allowDuplicated,
-      versionIfExists,
-    );
-    return formatToolResponse(result);
-  }
-);
+const attachmentGateway = resolveAttachmentGateway(CONFLUENCE_PRODUCT);
 
+// Filesystem-reading upload is only registered when the operator explicitly enables it.
+if (attachmentGateway.upload.enabled) {
+  server.tool(
+    "confluence_uploadAttachment",
+    `Upload a local file as an attachment to a Confluence content (page) in the ${confluenceInstanceType}. The file must live under the server-configured upload directory; the path is given relative to that directory.`,
+    confluenceToolSchemas.uploadAttachment,
+    async ({ contentId, sourcePath, filename, comment, minorEdit, hidden, allowDuplicated, versionIfExists }) => {
+      const result = await confluenceService.uploadAttachment(
+        contentId,
+        sourcePath,
+        attachmentGateway.upload,
+        filename,
+        comment,
+        minorEdit,
+        hidden,
+        allowDuplicated,
+        versionIfExists,
+      );
+      return formatToolResponse(result);
+    }
+  );
+}
+
+// Download always returns content inline (no filesystem access). Saving to disk is
+// only offered when the operator enables it, and is confined to the configured directory.
+const downloadSaveEnabled = attachmentGateway.download.enabled;
 server.tool(
   "confluence_downloadAttachment",
-  `Download one or more attachments from a Confluence content (page) in the ${confluenceInstanceType}. Can save to a local path and/or return the file content inline (base64 or text). Useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Jira issue).`,
-  confluenceToolSchemas.downloadAttachment,
-  async ({ contentId, filename, saveDir, savePath, returnContent, maxInlineBytes }) => {
-    const result = await confluenceService.downloadAttachmentFromContent(contentId, filename, {
-      saveDir,
-      savePath,
+  `Download one or more attachments from a Confluence content (page) in the ${confluenceInstanceType}. Returns the file content inline (base64 or text). Useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Jira issue).${downloadSaveEnabled ? ' Can also save into the server-configured download directory; existing files are never overwritten.' : ' Saving to local disk is disabled on this server.'}`,
+  { ...confluenceToolSchemas.downloadAttachment, ...(downloadSaveEnabled ? confluenceToolSchemas.downloadAttachmentSaveFields : {}) },
+  async ({ contentId, filename, returnContent, maxInlineBytes, save, saveName }: {
+    contentId: string;
+    filename?: string;
+    returnContent?: 'none' | 'base64' | 'text';
+    maxInlineBytes?: number;
+    save?: boolean;
+    saveName?: string;
+  }) => {
+    const result = await confluenceService.downloadAttachmentFromContent({
+      contentId,
+      filename,
+      save,
+      saveName,
       returnContent,
       maxInlineBytes,
+      downloadSide: attachmentGateway.download,
     });
     return formatToolResponse(result);
   }


### PR DESCRIPTION
Adds attachment support to the Confluence MCP server, with local filesystem access sandboxed behind an explicit, operator-controlled gateway.

## Security model

Filesystem access is **opt-in and off by default** — until an operator enables it, this server stays API-only, exactly as before. When enabled, access is confined to operator-configured directories that the model cannot choose. This addresses the review concern that an attachment tool could otherwise read arbitrary local files or overwrite local files with attachment content.

Configured via environment variables:

```
# Enable each direction separately (default: false)
CONFLUENCE_ATTACHMENTS_UPLOAD_ENABLED=true
CONFLUENCE_ATTACHMENTS_DOWNLOAD_ENABLED=true

# Allowed roots (os path-separator list); uploads read only from these,
# downloads write only into the first configured download root
CONFLUENCE_ATTACHMENTS_UPLOAD_ROOTS=/srv/confluence-exchange/in
CONFLUENCE_ATTACHMENTS_DOWNLOAD_ROOTS=/srv/confluence-exchange/out

# Convenience: one dedicated exchange directory used as both roots
CONFLUENCE_ATTACHMENTS_DIR=/srv/confluence-exchange

# Hard per-file size limits in bytes (default 25 MiB)
CONFLUENCE_ATTACHMENTS_MAX_UPLOAD_BYTES=26214400
CONFLUENCE_ATTACHMENTS_MAX_DOWNLOAD_BYTES=26214400
```

Guardrails when enabled:

- **Not registered unless enabled** — `confluence_uploadAttachment` (a pure filesystem read) is only registered when uploads are enabled. `confluence_downloadAttachment` is always registered but, with downloads disabled, can only return bytes **inline** (base64/text) — it never touches local disk.
- **Upload/download enabled separately** — independent flags.
- **Operator-owned roots, not model-selectable** — the model passes a path *relative* to a configured root (`sourcePath` for upload, optional `saveName` for download); absolute paths and `..` are rejected.
- **Canonicalized + contained** — roots are `realpath`-resolved at startup; each request canonicalizes the deepest existing ancestor and verifies it stays inside a root, so a symlinked parent directory can't be used to escape.
- **Symlink-safe** — uploads reject symlinks and non-regular files (FIFOs, devices, directories); downloads never follow a symlinked directory out of the root.
- **No overwrite** — downloads write with an exclusive (`wx`) flag, so an existing file (including a symlink) is never clobbered.
- **Hard size limits** — uploads checked before reading; downloads rejected on `Content-Length` and enforced again while streaming the body, so an oversized/mislabeled response can't exhaust memory.

## Tools

### `confluence_uploadAttachment`
Uploads a local file (resolved under an allowed upload root) as an attachment to a Confluence page via the generated `AttachmentsService`.
- Sets `X-Atlassian-Token: nocheck` for the multipart POST (XSRF bypass), restoring headers afterwards.
- Uses `File` from `node:buffer` for Node 18.13+ compatibility.
- `versionIfExists` uploads as a new version when an attachment with the same filename already exists.

### `confluence_downloadAttachment`
Downloads one attachment (by `filename`) or all attachments on a page.
- `returnContent` (`none` | `base64` | `text`, default `none`) — embed bytes inline so the AI can inspect the file directly; `maxInlineBytes` caps inline size (default 1 MiB). Available regardless of filesystem settings, since it writes nothing locally.
- `save` / `saveName` — write into the configured download directory (only offered when downloads are enabled; never overwrites).
- Resolves the relative `_links.download` against the site base (context path preserved).

Together these enable round-trips like downloading a file from Confluence and re-uploading it to a Jira issue.

## Shared helper + gateway
Adds two product-agnostic modules to `@atlassian-dc-mcp/common`:
- `attachment-download.ts` — authenticates with a Bearer token, sends `X-Atlassian-Token: nocheck`, enforces the hard download cap (streamed), and writes to a pre-validated destination with an exclusive flag.
- `attachment-gateway.ts` — parses the per-product `*_ATTACHMENTS_*` env vars, canonicalizes roots, and resolves/validates requested paths (containment, symlink, size).

> Note: the same `common` files are added identically in #35 (Jira). They are byte-identical, so the two PRs merge cleanly in either order.

## Tests
`common` (119) and `confluence` (31) all passing — added gateway resolution, upload-path, symlink-escape, oversize, and no-overwrite coverage. README updated for both tools and the new configuration.
