### PR TITLE
feat(jira): add upload & download attachment tools

### DIFF
--- a/packages/common/src/__tests__/attachment-download.test.ts
+++ b/packages/common/src/__tests__/attachment-download.test.ts
@@ -1,34 +1,37 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { downloadAttachment, resolveSafeChildPath } from '../attachment-download.js';
+import { downloadAttachment } from '../attachment-download.js';
 
-function mockFetchOnce(body: Buffer, init?: { ok?: boolean; status?: number; statusText?: string; contentType?: string }) {
+function mockFetchOnce(
+  body: Buffer,
+  init?: { ok?: boolean; status?: number; statusText?: string; contentType?: string; contentLength?: string; stream?: boolean },
+) {
   const ok = init?.ok ?? true;
-  global.fetch = jest.fn().mockResolvedValue({
+  const headers = new Map<string, string>();
+  if (init?.contentType) headers.set('content-type', init.contentType);
+  if (init?.contentLength) headers.set('content-length', init.contentLength);
+
+  const response: Record<string, unknown> = {
     ok,
     status: init?.status ?? (ok ? 200 : 500),
     statusText: init?.statusText ?? (ok ? 'OK' : 'Error'),
-    headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? init?.contentType ?? null : null) },
+    headers: { get: (name: string) => headers.get(name.toLowerCase()) ?? null },
     arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
-  }) as unknown as typeof fetch;
+  };
+
+  if (init?.stream) {
+    let sent = false;
+    response.body = {
+      getReader: () => ({
+        read: async () => (sent ? { done: true, value: undefined } : ((sent = true), { done: false, value: new Uint8Array(body) })),
+        cancel: async () => undefined,
+      }),
+    };
+  }
+
+  global.fetch = jest.fn().mockResolvedValue(response) as unknown as typeof fetch;
 }
-
-describe('resolveSafeChildPath', () => {
-  it('joins the basename of the filename to the directory', () => {
-    expect(resolveSafeChildPath('/tmp/out', 'file.txt')).toBe(path.resolve('/tmp/out', 'file.txt'));
-  });
-
-  it('strips directory components from the filename (traversal defense)', () => {
-    expect(resolveSafeChildPath('/tmp/out', '../../etc/passwd')).toBe(path.resolve('/tmp/out', 'passwd'));
-    expect(resolveSafeChildPath('/tmp/out', '/etc/passwd')).toBe(path.resolve('/tmp/out', 'passwd'));
-  });
-
-  it('rejects filenames that resolve to the directory itself', () => {
-    expect(() => resolveSafeChildPath('/tmp/out', '..')).toThrow();
-    expect(() => resolveSafeChildPath('/tmp/out', '.')).toThrow();
-  });
-});
 
 describe('downloadAttachment', () => {
   let tmpDir: string;
@@ -42,23 +45,35 @@ describe('downloadAttachment', () => {
     jest.restoreAllMocks();
   });
 
-  it('saves the file to saveDir using the filename and reports metadata', async () => {
+  it('writes the file to the provided destination and reports metadata', async () => {
     mockFetchOnce(Buffer.from('hello world'), { contentType: 'text/plain' });
+    const destination = path.join(tmpDir, 'note.txt');
 
     const result = await downloadAttachment({
       url: 'https://host/download/x',
       token: 'tok',
       filename: 'note.txt',
-      options: { saveDir: tmpDir },
+      options: { destination },
     });
 
     expect(global.fetch).toHaveBeenCalledWith('https://host/download/x', {
       headers: { Authorization: 'Bearer tok', 'X-Atlassian-Token': 'nocheck' },
     });
-    expect(result.savedPath).toBe(path.join(tmpDir, 'note.txt'));
+    expect(result.savedPath).toBe(destination);
     expect(result.size).toBe(11);
-    expect(fs.readFileSync(result.savedPath!, 'utf-8')).toBe('hello world');
+    expect(fs.readFileSync(destination, 'utf-8')).toBe('hello world');
     expect(result.content).toBeUndefined();
+  });
+
+  it('refuses to overwrite an existing destination file', async () => {
+    mockFetchOnce(Buffer.from('new content'));
+    const destination = path.join(tmpDir, 'exists.txt');
+    fs.writeFileSync(destination, 'original');
+
+    await expect(
+      downloadAttachment({ url: 'https://host/x', token: 'tok', filename: 'exists.txt', options: { destination } }),
+    ).rejects.toThrow();
+    expect(fs.readFileSync(destination, 'utf-8')).toBe('original');
   });
 
   it('returns text content inline when requested', async () => {
@@ -103,6 +118,30 @@ describe('downloadAttachment', () => {
 
     expect(result.content).toBeUndefined();
     expect(result.contentOmittedReason).toContain('exceeds inline cap');
+  });
+
+  it('rejects early when content-length exceeds the download cap', async () => {
+    mockFetchOnce(Buffer.from('1234567890'), { contentLength: '10' });
+
+    await expect(
+      downloadAttachment({ url: 'https://host/x', token: 'tok', filename: 'big.bin', options: { maxDownloadBytes: 5 } }),
+    ).rejects.toThrow('exceeds the configured download limit');
+  });
+
+  it('aborts a streamed body that exceeds the download cap', async () => {
+    mockFetchOnce(Buffer.from('1234567890'), { stream: true });
+
+    await expect(
+      downloadAttachment({ url: 'https://host/x', token: 'tok', filename: 'big.bin', options: { maxDownloadBytes: 5 } }),
+    ).rejects.toThrow('exceeds the configured download limit');
+  });
+
+  it('enforces the cap on a buffered body without content-length', async () => {
+    mockFetchOnce(Buffer.from('1234567890'));
+
+    await expect(
+      downloadAttachment({ url: 'https://host/x', token: 'tok', filename: 'big.bin', options: { maxDownloadBytes: 5 } }),
+    ).rejects.toThrow('exceeds the configured download limit');
   });
 
   it('throws when the response is not ok', async () => {

--- a/packages/common/src/__tests__/attachment-download.test.ts
+++ b/packages/common/src/__tests__/attachment-download.test.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { downloadAttachment, resolveSafeChildPath } from '../attachment-download.js';
+
+function mockFetchOnce(body: Buffer, init?: { ok?: boolean; status?: number; statusText?: string; contentType?: string }) {
+  const ok = init?.ok ?? true;
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    status: init?.status ?? (ok ? 200 : 500),
+    statusText: init?.statusText ?? (ok ? 'OK' : 'Error'),
+    headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? init?.contentType ?? null : null) },
+    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+  }) as unknown as typeof fetch;
+}
+
+describe('resolveSafeChildPath', () => {
+  it('joins the basename of the filename to the directory', () => {
+    expect(resolveSafeChildPath('/tmp/out', 'file.txt')).toBe(path.resolve('/tmp/out', 'file.txt'));
+  });
+
+  it('strips directory components from the filename (traversal defense)', () => {
+    expect(resolveSafeChildPath('/tmp/out', '../../etc/passwd')).toBe(path.resolve('/tmp/out', 'passwd'));
+    expect(resolveSafeChildPath('/tmp/out', '/etc/passwd')).toBe(path.resolve('/tmp/out', 'passwd'));
+  });
+
+  it('rejects filenames that resolve to the directory itself', () => {
+    expect(() => resolveSafeChildPath('/tmp/out', '..')).toThrow();
+    expect(() => resolveSafeChildPath('/tmp/out', '.')).toThrow();
+  });
+});
+
+describe('downloadAttachment', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mcp-dl-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  it('saves the file to saveDir using the filename and reports metadata', async () => {
+    mockFetchOnce(Buffer.from('hello world'), { contentType: 'text/plain' });
+
+    const result = await downloadAttachment({
+      url: 'https://host/download/x',
+      token: 'tok',
+      filename: 'note.txt',
+      options: { saveDir: tmpDir },
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('https://host/download/x', {
+      headers: { Authorization: 'Bearer tok', 'X-Atlassian-Token': 'nocheck' },
+    });
+    expect(result.savedPath).toBe(path.join(tmpDir, 'note.txt'));
+    expect(result.size).toBe(11);
+    expect(fs.readFileSync(result.savedPath!, 'utf-8')).toBe('hello world');
+    expect(result.content).toBeUndefined();
+  });
+
+  it('returns text content inline when requested', async () => {
+    mockFetchOnce(Buffer.from('inline text'));
+
+    const result = await downloadAttachment({
+      url: 'https://host/download/x',
+      token: () => 'tok',
+      filename: 'note.txt',
+      options: { returnContent: 'text' },
+    });
+
+    expect(result.content).toBe('inline text');
+    expect(result.encoding).toBe('text');
+    expect(result.savedPath).toBeUndefined();
+  });
+
+  it('returns base64 content inline when requested', async () => {
+    const bytes = Buffer.from([0x00, 0x01, 0x02, 0xff]);
+    mockFetchOnce(bytes);
+
+    const result = await downloadAttachment({
+      url: 'https://host/download/x',
+      token: 'tok',
+      filename: 'blob.bin',
+      options: { returnContent: 'base64' },
+    });
+
+    expect(result.content).toBe(bytes.toString('base64'));
+    expect(result.encoding).toBe('base64');
+  });
+
+  it('omits inline content when the file exceeds maxInlineBytes', async () => {
+    mockFetchOnce(Buffer.from('123456'));
+
+    const result = await downloadAttachment({
+      url: 'https://host/download/x',
+      token: 'tok',
+      filename: 'big.txt',
+      options: { returnContent: 'text', maxInlineBytes: 3 },
+    });
+
+    expect(result.content).toBeUndefined();
+    expect(result.contentOmittedReason).toContain('exceeds inline cap');
+  });
+
+  it('throws when the response is not ok', async () => {
+    mockFetchOnce(Buffer.from(''), { ok: false, status: 404, statusText: 'Not Found' });
+
+    await expect(
+      downloadAttachment({ url: 'https://host/x', token: 'tok', filename: 'f.txt' }),
+    ).rejects.toThrow('404 Not Found');
+  });
+
+  it('throws when no token is available', async () => {
+    mockFetchOnce(Buffer.from(''));
+
+    await expect(
+      downloadAttachment({ url: 'https://host/x', token: () => undefined, filename: 'f.txt' }),
+    ).rejects.toThrow('Missing API token');
+  });
+});

--- a/packages/common/src/__tests__/attachment-gateway.test.ts
+++ b/packages/common/src/__tests__/attachment-gateway.test.ts
@@ -1,0 +1,156 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DEFAULT_MAX_ATTACHMENT_BYTES,
+  resolveAttachmentGateway,
+  resolveDownloadDestination,
+  resolveUploadSource,
+} from '../attachment-gateway.js';
+import type { ProductDefinition } from '../config/source.js';
+
+const PRODUCT: ProductDefinition = {
+  id: 'jira',
+  envVars: { host: 'JIRA_HOST', apiBasePath: 'JIRA_API_BASE_PATH', token: 'JIRA_API_TOKEN', defaultPageSize: 'JIRA_DEFAULT_PAGE_SIZE' },
+};
+
+const silentWarn = () => undefined;
+
+describe('resolveAttachmentGateway', () => {
+  let root: string;
+  let realRoot: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mcp-gw-'));
+    realRoot = fs.realpathSync(root);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('is disabled by default', () => {
+    const gw = resolveAttachmentGateway(PRODUCT, { env: {}, warn: silentWarn });
+    expect(gw.upload.enabled).toBe(false);
+    expect(gw.download.enabled).toBe(false);
+  });
+
+  it('stays disabled when enabled but no valid root is configured', () => {
+    const gw = resolveAttachmentGateway(PRODUCT, {
+      env: { JIRA_ATTACHMENTS_UPLOAD_ENABLED: 'true' },
+      warn: silentWarn,
+    });
+    expect(gw.upload.enabled).toBe(false);
+  });
+
+  it('enables upload with a canonical root and default size limit', () => {
+    const gw = resolveAttachmentGateway(PRODUCT, {
+      env: { JIRA_ATTACHMENTS_UPLOAD_ENABLED: 'true', JIRA_ATTACHMENTS_UPLOAD_ROOTS: root },
+      warn: silentWarn,
+    });
+    expect(gw.upload.enabled).toBe(true);
+    expect(gw.upload.roots).toEqual([realRoot]);
+    expect(gw.upload.maxBytes).toBe(DEFAULT_MAX_ATTACHMENT_BYTES);
+  });
+
+  it('uses JIRA_ATTACHMENTS_DIR as a shared exchange root and honours size overrides', () => {
+    const gw = resolveAttachmentGateway(PRODUCT, {
+      env: {
+        JIRA_ATTACHMENTS_UPLOAD_ENABLED: 'true',
+        JIRA_ATTACHMENTS_DOWNLOAD_ENABLED: '1',
+        JIRA_ATTACHMENTS_DIR: root,
+        JIRA_ATTACHMENTS_MAX_UPLOAD_BYTES: '1024',
+      },
+      warn: silentWarn,
+    });
+    expect(gw.upload.roots).toEqual([realRoot]);
+    expect(gw.download.roots).toEqual([realRoot]);
+    expect(gw.upload.maxBytes).toBe(1024);
+  });
+});
+
+describe('resolveUploadSource', () => {
+  let root: string;
+  const side = () => ({ enabled: true, roots: [fs.realpathSync(root)], maxBytes: 100 });
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mcp-up-'));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('resolves a regular file inside the root', async () => {
+    fs.writeFileSync(path.join(root, 'a.txt'), 'hi');
+    const { absolutePath, size } = await resolveUploadSource({ requestedPath: 'a.txt', side: side() });
+    expect(absolutePath).toBe(path.join(fs.realpathSync(root), 'a.txt'));
+    expect(size).toBe(2);
+  });
+
+  it('rejects absolute paths', async () => {
+    await expect(resolveUploadSource({ requestedPath: '/etc/passwd', side: side() })).rejects.toThrow('not absolute');
+  });
+
+  it('rejects traversal outside the root', async () => {
+    await expect(resolveUploadSource({ requestedPath: '../secret', side: side() })).rejects.toThrow('within the configured');
+  });
+
+  it('rejects a symlink leaf', async () => {
+    const target = path.join(root, 'real.txt');
+    fs.writeFileSync(target, 'secret');
+    fs.symlinkSync(target, path.join(root, 'link.txt'));
+    await expect(resolveUploadSource({ requestedPath: 'link.txt', side: side() })).rejects.toThrow('symlink');
+  });
+
+  it('rejects a path that escapes via a symlinked directory', async () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mcp-out-'));
+    fs.writeFileSync(path.join(outside, 'secret.txt'), 'x');
+    fs.symlinkSync(outside, path.join(root, 'escape'));
+    await expect(resolveUploadSource({ requestedPath: 'escape/secret.txt', side: side() })).rejects.toThrow('outside');
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+
+  it('rejects a non-regular file (directory)', async () => {
+    fs.mkdirSync(path.join(root, 'sub'));
+    await expect(resolveUploadSource({ requestedPath: 'sub', side: side() })).rejects.toThrow('non-regular');
+  });
+
+  it('rejects a file over the size limit', async () => {
+    fs.writeFileSync(path.join(root, 'big.txt'), 'x'.repeat(200));
+    await expect(resolveUploadSource({ requestedPath: 'big.txt', side: side() })).rejects.toThrow('exceeds the configured upload limit');
+  });
+
+  it('throws when upload is disabled', async () => {
+    await expect(
+      resolveUploadSource({ requestedPath: 'a.txt', side: { enabled: false, roots: [], maxBytes: 100 } }),
+    ).rejects.toThrow('disabled');
+  });
+});
+
+describe('resolveDownloadDestination', () => {
+  let root: string;
+  const side = () => ({ enabled: true, roots: [fs.realpathSync(root)], maxBytes: 100 });
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mcp-dd-'));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('resolves a basename into the download root', async () => {
+    const dest = await resolveDownloadDestination({ requestedName: 'out.bin', side: side() });
+    expect(dest).toBe(path.join(fs.realpathSync(root), 'out.bin'));
+  });
+
+  it('strips directory components from the requested name', async () => {
+    const dest = await resolveDownloadDestination({ requestedName: '../../etc/passwd', side: side() });
+    expect(dest).toBe(path.join(fs.realpathSync(root), 'passwd'));
+  });
+
+  it('throws when saving is disabled', async () => {
+    await expect(
+      resolveDownloadDestination({ requestedName: 'out.bin', side: { enabled: false, roots: [], maxBytes: 100 } }),
+    ).rejects.toThrow('disabled');
+  });
+});

--- a/packages/common/src/attachment-download.ts
+++ b/packages/common/src/attachment-download.ts
@@ -1,5 +1,5 @@
-import { mkdir, writeFile } from 'node:fs/promises';
-import { basename, dirname, isAbsolute, resolve, sep } from 'node:path';
+import { writeFile } from 'node:fs/promises';
+import { basename } from 'node:path';
 
 /**
  * How the downloaded bytes should be returned to the caller inline, in addition
@@ -14,14 +14,19 @@ export type AttachmentContentEncoding = 'none' | 'base64' | 'text';
 export const DEFAULT_MAX_INLINE_BYTES = 1_048_576;
 
 export interface AttachmentDownloadOptions {
-  /** Explicit destination file path. Takes precedence over saveDir. */
-  savePath?: string;
-  /** Destination directory; the (sanitized) filename is appended to it. */
-  saveDir?: string;
+  /**
+   * Absolute, already-validated destination path to write the bytes to. Resolving
+   * and sandboxing this path is the caller's responsibility (see the attachment
+   * gateway); the file is written with an exclusive flag and never overwrites an
+   * existing file. When omitted, nothing is written to disk.
+   */
+  destination?: string;
   /** Whether and how to embed the bytes in the response. Defaults to `none`. */
   returnContent?: AttachmentContentEncoding;
   /** Maximum bytes to embed inline when returnContent is not `none`. */
   maxInlineBytes?: number;
+  /** Hard cap on the number of downloaded bytes. Exceeding it aborts the download. */
+  maxDownloadBytes?: number;
 }
 
 export interface AttachmentDownloadResult {
@@ -47,39 +52,47 @@ async function resolveToken(token: string | (() => string | undefined)): Promise
 }
 
 /**
- * Resolves a destination path for a downloaded file inside `saveDir`, guarding
- * against path traversal: only the basename of `filename` is used, and the
- * resolved path must stay within `saveDir`.
+ * Reads the response body, enforcing `cap` (when set) without buffering more than
+ * the limit. Streams chunk-by-chunk when a web ReadableStream is available and
+ * falls back to a buffered read with a post-check otherwise.
  */
-export function resolveSafeChildPath(saveDir: string, filename: string): string {
-  const safeName = basename(filename);
-  if (!safeName || safeName === '.' || safeName === '..') {
-    throw new Error(`Unsafe attachment filename: "${filename}"`);
+async function readBodyWithCap(response: Response, cap: number | undefined, filename: string): Promise<Buffer> {
+  const body = response.body as ReadableStream<Uint8Array> | null;
+  if (cap !== undefined && body && typeof body.getReader === 'function') {
+    const reader = body.getReader();
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      total += value.byteLength;
+      if (total > cap) {
+        await reader.cancel();
+        throw new Error(`Attachment "${filename}" exceeds the configured download limit of ${cap} bytes`);
+      }
+      chunks.push(Buffer.from(value));
+    }
+    return Buffer.concat(chunks);
   }
-  const baseDir = resolve(saveDir);
-  const target = resolve(baseDir, safeName);
-  if (target !== baseDir && !target.startsWith(baseDir + sep)) {
-    throw new Error(`Refusing to write outside of target directory: "${filename}"`);
-  }
-  return target;
-}
 
-function resolveDestination(filename: string, options: AttachmentDownloadOptions): string | undefined {
-  if (options.savePath) {
-    return isAbsolute(options.savePath) ? options.savePath : resolve(options.savePath);
+  const buffer = Buffer.from(await response.arrayBuffer());
+  if (cap !== undefined && buffer.length > cap) {
+    throw new Error(
+      `Attachment "${filename}" size ${buffer.length} bytes exceeds the configured download limit of ${cap} bytes`,
+    );
   }
-  if (options.saveDir) {
-    return resolveSafeChildPath(options.saveDir, filename);
-  }
-  return undefined;
+  return buffer;
 }
 
 /**
  * Downloads a file from an authenticated Atlassian Data Center URL using a
- * Bearer token, optionally writing it to disk and/or returning its bytes inline.
+ * Bearer token, optionally writing it to a pre-validated destination and/or
+ * returning its bytes inline.
  *
- * The bytes are buffered in memory; this is intended for typical attachment
- * sizes rather than very large files.
+ * Writing uses an exclusive flag, so an existing file (including a symlink) is
+ * never overwritten.
  */
 export async function downloadAttachment(params: {
   url: string;
@@ -104,7 +117,15 @@ export async function downloadAttachment(params: {
     throw new Error(`Failed to download attachment "${filename}": ${response.status} ${response.statusText}`);
   }
 
-  const buffer = Buffer.from(await response.arrayBuffer());
+  const cap = options.maxDownloadBytes;
+  const declaredLength = Number(response.headers.get('content-length'));
+  if (cap !== undefined && Number.isFinite(declaredLength) && declaredLength > cap) {
+    throw new Error(
+      `Attachment "${filename}" size ${declaredLength} bytes exceeds the configured download limit of ${cap} bytes`,
+    );
+  }
+
+  const buffer = await readBodyWithCap(response, cap, filename);
   const resolvedMediaType = mediaType ?? response.headers.get('content-type') ?? undefined;
 
   const result: AttachmentDownloadResult = {
@@ -113,18 +134,16 @@ export async function downloadAttachment(params: {
     size: buffer.length,
   };
 
-  const destination = resolveDestination(filename, options);
-  if (destination) {
-    await mkdir(dirname(destination), { recursive: true });
-    await writeFile(destination, buffer);
-    result.savedPath = destination;
+  if (options.destination) {
+    await writeFile(options.destination, buffer, { flag: 'wx' });
+    result.savedPath = options.destination;
   }
 
   const returnContent = options.returnContent ?? 'none';
   if (returnContent !== 'none') {
-    const cap = options.maxInlineBytes ?? DEFAULT_MAX_INLINE_BYTES;
-    if (buffer.length > cap) {
-      result.contentOmittedReason = `File size ${buffer.length} bytes exceeds inline cap of ${cap} bytes`;
+    const inlineCap = options.maxInlineBytes ?? DEFAULT_MAX_INLINE_BYTES;
+    if (buffer.length > inlineCap) {
+      result.contentOmittedReason = `File size ${buffer.length} bytes exceeds inline cap of ${inlineCap} bytes`;
     } else {
       result.content = returnContent === 'base64' ? buffer.toString('base64') : buffer.toString('utf-8');
       result.encoding = returnContent;

--- a/packages/common/src/attachment-download.ts
+++ b/packages/common/src/attachment-download.ts
@@ -1,0 +1,135 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, resolve, sep } from 'node:path';
+
+/**
+ * How the downloaded bytes should be returned to the caller inline, in addition
+ * to (or instead of) being written to disk.
+ * - `none`: do not embed the bytes in the response (default)
+ * - `base64`: embed base64-encoded bytes (suitable for binary files)
+ * - `text`: embed the bytes decoded as UTF-8 text (suitable for text files)
+ */
+export type AttachmentContentEncoding = 'none' | 'base64' | 'text';
+
+/** Default cap for inline content so responses do not balloon. 1 MiB. */
+export const DEFAULT_MAX_INLINE_BYTES = 1_048_576;
+
+export interface AttachmentDownloadOptions {
+  /** Explicit destination file path. Takes precedence over saveDir. */
+  savePath?: string;
+  /** Destination directory; the (sanitized) filename is appended to it. */
+  saveDir?: string;
+  /** Whether and how to embed the bytes in the response. Defaults to `none`. */
+  returnContent?: AttachmentContentEncoding;
+  /** Maximum bytes to embed inline when returnContent is not `none`. */
+  maxInlineBytes?: number;
+}
+
+export interface AttachmentDownloadResult {
+  filename: string;
+  mediaType?: string;
+  /** Number of bytes downloaded. */
+  size: number;
+  /** Absolute path the file was written to, when saving was requested. */
+  savedPath?: string;
+  /** Inline content, when returnContent is `base64` or `text`. */
+  content?: string;
+  encoding?: 'base64' | 'text';
+  /** Set when inline content was requested but omitted (e.g. over the size cap). */
+  contentOmittedReason?: string;
+}
+
+async function resolveToken(token: string | (() => string | undefined)): Promise<string> {
+  const resolved = typeof token === 'function' ? token() : token;
+  if (!resolved) {
+    throw new Error('Missing API token for attachment download');
+  }
+  return resolved;
+}
+
+/**
+ * Resolves a destination path for a downloaded file inside `saveDir`, guarding
+ * against path traversal: only the basename of `filename` is used, and the
+ * resolved path must stay within `saveDir`.
+ */
+export function resolveSafeChildPath(saveDir: string, filename: string): string {
+  const safeName = basename(filename);
+  if (!safeName || safeName === '.' || safeName === '..') {
+    throw new Error(`Unsafe attachment filename: "${filename}"`);
+  }
+  const baseDir = resolve(saveDir);
+  const target = resolve(baseDir, safeName);
+  if (target !== baseDir && !target.startsWith(baseDir + sep)) {
+    throw new Error(`Refusing to write outside of target directory: "${filename}"`);
+  }
+  return target;
+}
+
+function resolveDestination(filename: string, options: AttachmentDownloadOptions): string | undefined {
+  if (options.savePath) {
+    return isAbsolute(options.savePath) ? options.savePath : resolve(options.savePath);
+  }
+  if (options.saveDir) {
+    return resolveSafeChildPath(options.saveDir, filename);
+  }
+  return undefined;
+}
+
+/**
+ * Downloads a file from an authenticated Atlassian Data Center URL using a
+ * Bearer token, optionally writing it to disk and/or returning its bytes inline.
+ *
+ * The bytes are buffered in memory; this is intended for typical attachment
+ * sizes rather than very large files.
+ */
+export async function downloadAttachment(params: {
+  url: string;
+  token: string | (() => string | undefined);
+  filename: string;
+  mediaType?: string;
+  options?: AttachmentDownloadOptions;
+}): Promise<AttachmentDownloadResult> {
+  const { url, filename, mediaType } = params;
+  const options = params.options ?? {};
+  const token = await resolveToken(params.token);
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      // Attachment download endpoints are XSRF-protected; nocheck bypasses it.
+      'X-Atlassian-Token': 'nocheck',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to download attachment "${filename}": ${response.status} ${response.statusText}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const resolvedMediaType = mediaType ?? response.headers.get('content-type') ?? undefined;
+
+  const result: AttachmentDownloadResult = {
+    filename: basename(filename),
+    mediaType: resolvedMediaType,
+    size: buffer.length,
+  };
+
+  const destination = resolveDestination(filename, options);
+  if (destination) {
+    await mkdir(dirname(destination), { recursive: true });
+    await writeFile(destination, buffer);
+    result.savedPath = destination;
+  }
+
+  const returnContent = options.returnContent ?? 'none';
+  if (returnContent !== 'none') {
+    const cap = options.maxInlineBytes ?? DEFAULT_MAX_INLINE_BYTES;
+    if (buffer.length > cap) {
+      result.contentOmittedReason = `File size ${buffer.length} bytes exceeds inline cap of ${cap} bytes`;
+    } else {
+      result.content = returnContent === 'base64' ? buffer.toString('base64') : buffer.toString('utf-8');
+      result.encoding = returnContent;
+    }
+  }
+
+  return result;
+}

--- a/packages/common/src/attachment-gateway.ts
+++ b/packages/common/src/attachment-gateway.ts
@@ -1,0 +1,255 @@
+import { realpathSync } from 'node:fs';
+import { lstat, realpath } from 'node:fs/promises';
+import { basename, delimiter, dirname, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
+import type { ProductDefinition } from './config/source.js';
+
+/**
+ * Operator-controlled gateway that lets the attachment tools read from / write to
+ * the local filesystem. It is disabled by default: filesystem access must be
+ * explicitly enabled and confined to canonical root directories that the model
+ * cannot choose. Configured entirely through environment variables named after
+ * the product (e.g. JIRA_ATTACHMENTS_*).
+ */
+export const DEFAULT_MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024; // 25 MiB
+
+export interface AttachmentGatewaySide {
+  /** Whether this direction (upload/download) is enabled with a valid root. */
+  enabled: boolean;
+  /** Canonical (realpath-resolved) absolute root directories. */
+  roots: string[];
+  /** Hard byte limit for a single file in this direction. */
+  maxBytes: number;
+}
+
+export interface AttachmentGateway {
+  upload: AttachmentGatewaySide;
+  download: AttachmentGatewaySide;
+}
+
+type Env = Record<string, string | undefined>;
+type Warn = (message: string) => void;
+
+function envPrefix(product: ProductDefinition): string {
+  return product.id.toUpperCase();
+}
+
+function readBool(env: Env, name: string): boolean {
+  const value = env[name]?.trim().toLowerCase();
+  return value === 'true' || value === '1' || value === 'yes';
+}
+
+function readBytes(env: Env, name: string): number | undefined {
+  const raw = env[name]?.trim();
+  if (!raw || !/^\d+$/.test(raw)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return parsed > 0 ? parsed : undefined;
+}
+
+function readRoots(env: Env, names: string[]): string[] {
+  const roots: string[] = [];
+  for (const name of names) {
+    const raw = env[name];
+    if (!raw) {
+      continue;
+    }
+    for (const part of raw.split(delimiter)) {
+      const trimmed = part.trim();
+      if (trimmed) {
+        roots.push(trimmed);
+      }
+    }
+  }
+  return roots;
+}
+
+function canonicalizeRoots(rawRoots: string[], warn: Warn): string[] {
+  const canonical: string[] = [];
+  for (const root of rawRoots) {
+    if (!isAbsolute(root)) {
+      warn(`Ignoring attachment root that is not an absolute path: "${root}"`);
+      continue;
+    }
+    try {
+      const real = realpathSync(root);
+      if (!canonical.includes(real)) {
+        canonical.push(real);
+      }
+    } catch {
+      warn(`Ignoring attachment root that does not exist or cannot be resolved: "${root}"`);
+    }
+  }
+  return canonical;
+}
+
+function resolveSide(args: {
+  enabledFlag: boolean;
+  rawRoots: string[];
+  maxBytes: number;
+  label: string;
+  rootEnvHint: string;
+  warn: Warn;
+}): AttachmentGatewaySide {
+  if (!args.enabledFlag) {
+    return { enabled: false, roots: [], maxBytes: args.maxBytes };
+  }
+  const roots = canonicalizeRoots(args.rawRoots, args.warn);
+  if (roots.length === 0) {
+    args.warn(
+      `${args.label} attachments were enabled but no valid directory is configured ` +
+        `(set ${args.rootEnvHint}); the ${args.label} tool will stay disabled.`,
+    );
+    return { enabled: false, roots: [], maxBytes: args.maxBytes };
+  }
+  return { enabled: true, roots, maxBytes: args.maxBytes };
+}
+
+/**
+ * Reads the attachment gateway configuration for a product from the environment.
+ * Roots are canonicalized once here; a direction is only reported as enabled when
+ * its flag is set and at least one valid root resolves.
+ */
+export function resolveAttachmentGateway(
+  product: ProductDefinition,
+  options?: { env?: Env; warn?: Warn },
+): AttachmentGateway {
+  const env = options?.env ?? process.env;
+  const warn = options?.warn ?? ((message: string) => console.error(`[attachment-gateway] ${message}`));
+  const p = envPrefix(product);
+
+  const exchangeDir = env[`${p}_ATTACHMENTS_DIR`]?.trim();
+  const dirRoots = exchangeDir ? [exchangeDir] : [];
+
+  const upload = resolveSide({
+    enabledFlag: readBool(env, `${p}_ATTACHMENTS_UPLOAD_ENABLED`),
+    rawRoots: [...readRoots(env, [`${p}_ATTACHMENTS_UPLOAD_ROOTS`]), ...dirRoots],
+    maxBytes: readBytes(env, `${p}_ATTACHMENTS_MAX_UPLOAD_BYTES`) ?? DEFAULT_MAX_ATTACHMENT_BYTES,
+    label: 'upload',
+    rootEnvHint: `${p}_ATTACHMENTS_UPLOAD_ROOTS or ${p}_ATTACHMENTS_DIR`,
+    warn,
+  });
+
+  const download = resolveSide({
+    enabledFlag: readBool(env, `${p}_ATTACHMENTS_DOWNLOAD_ENABLED`),
+    rawRoots: [...readRoots(env, [`${p}_ATTACHMENTS_DOWNLOAD_ROOTS`]), ...dirRoots],
+    maxBytes: readBytes(env, `${p}_ATTACHMENTS_MAX_DOWNLOAD_BYTES`) ?? DEFAULT_MAX_ATTACHMENT_BYTES,
+    label: 'download',
+    rootEnvHint: `${p}_ATTACHMENTS_DOWNLOAD_ROOTS or ${p}_ATTACHMENTS_DIR`,
+    warn,
+  });
+
+  return { upload, download };
+}
+
+function normalizeRelative(requested: string): string {
+  if (!requested || !requested.trim()) {
+    throw new Error('A file path is required');
+  }
+  if (isAbsolute(requested)) {
+    throw new Error(`Path must be relative to a configured attachment root, not absolute: "${requested}"`);
+  }
+  const norm = normalize(requested);
+  if (norm === '.' || norm === '..' || norm === '' || norm.startsWith(`..${sep}`) || norm.startsWith('../')) {
+    throw new Error(`Path must stay within the configured attachment root: "${requested}"`);
+  }
+  return norm;
+}
+
+function withinRoot(candidate: string, root: string): boolean {
+  return candidate === root || candidate.startsWith(root + sep);
+}
+
+/**
+ * Canonicalizes the deepest existing ancestor of `target` (resolving symlinked
+ * directories) and re-attaches the not-yet-existing tail. Used to confirm a path
+ * cannot escape a root through a symlinked parent directory.
+ */
+async function canonicalizeDeepestExisting(target: string): Promise<string> {
+  let current = target;
+  while (true) {
+    try {
+      const real = await realpath(current);
+      const tail = relative(current, target);
+      return tail ? join(real, tail) : real;
+    } catch {
+      const parent = dirname(current);
+      if (parent === current) {
+        throw new Error(`Cannot resolve path: "${target}"`);
+      }
+      current = parent;
+    }
+  }
+}
+
+/**
+ * Resolves `requested` (relative) against the allowed roots, returning an absolute
+ * path whose parent directory is canonically inside a root. The final path
+ * component is NOT symlink-resolved, so callers can still detect a symlinked leaf.
+ */
+async function resolveLeafWithinRoots(requested: string, roots: string[]): Promise<string> {
+  const norm = normalizeRelative(requested);
+  for (const root of roots) {
+    const lexical = resolve(root, norm);
+    if (!withinRoot(lexical, root)) {
+      continue;
+    }
+    const parentReal = await canonicalizeDeepestExisting(dirname(lexical));
+    if (withinRoot(parentReal, root)) {
+      return join(parentReal, basename(lexical));
+    }
+  }
+  throw new Error(`Path resolves outside the configured attachment root(s): "${requested}"`);
+}
+
+/**
+ * Resolves and validates a file to upload: it must live inside an allowed upload
+ * root, be a regular file (never a symlink or special file), and be within the
+ * size limit. Returns the absolute path to read.
+ */
+export async function resolveUploadSource(params: {
+  requestedPath: string;
+  side: AttachmentGatewaySide;
+}): Promise<{ absolutePath: string; size: number }> {
+  if (!params.side.enabled) {
+    throw new Error('Attachment upload from the local filesystem is disabled on this server');
+  }
+  const absolutePath = await resolveLeafWithinRoots(params.requestedPath, params.side.roots);
+  const info = await lstat(absolutePath);
+  if (info.isSymbolicLink()) {
+    throw new Error(`Refusing to upload a symlink: "${params.requestedPath}"`);
+  }
+  if (!info.isFile()) {
+    throw new Error(`Refusing to upload a non-regular file: "${params.requestedPath}"`);
+  }
+  if (info.size > params.side.maxBytes) {
+    throw new Error(
+      `File size ${info.size} bytes exceeds the configured upload limit of ${params.side.maxBytes} bytes`,
+    );
+  }
+  return { absolutePath, size: info.size };
+}
+
+/**
+ * Resolves a destination path to save a downloaded attachment into. The file is
+ * placed in the first configured download root; the caller writes with an
+ * exclusive flag so existing files (including symlinks) are never overwritten.
+ */
+export async function resolveDownloadDestination(params: {
+  requestedName: string;
+  side: AttachmentGatewaySide;
+}): Promise<string> {
+  if (!params.side.enabled) {
+    throw new Error('Saving attachments to the local filesystem is disabled on this server');
+  }
+  const safeName = basename(params.requestedName);
+  if (!safeName || safeName === '.' || safeName === '..') {
+    throw new Error(`Invalid attachment file name: "${params.requestedName}"`);
+  }
+  return resolveLeafWithinRoots(safeName, [params.side.roots[0]]);
+}
+
+/** Resolves a path within roots, throwing if it escapes. Exported for verification/tests. */
+export async function assertWithinRoots(requested: string, roots: string[]): Promise<string> {
+  return resolveLeafWithinRoots(requested, roots);
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 export * from './api-error-handler.js'
+export * from './attachment-download.js'
 export * from './config/index.js';
 export { runSetup, runSetupCli } from './setup-cli.js';
 export { describeValidationError } from './setup/describe-error.js';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,6 +3,7 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 export * from './api-error-handler.js'
 export * from './attachment-download.js'
+export * from './attachment-gateway.js'
 export * from './config/index.js';
 export { runSetup, runSetupCli } from './setup-cli.js';
 export { describeValidationError } from './setup/describe-error.js';

--- a/packages/jira/README.md
+++ b/packages/jira/README.md
@@ -247,3 +247,25 @@ Parameters:
 - `issueKey` (string, required): The issue key (e.g., "PROJECT-123")
 - `transitionId` (string, required): Transition ID returned by `jira_getTransitions`
 - `fields` (object, optional): Additional fields required by the transition screen
+
+#### 9. jira_uploadAttachment
+
+Upload a local file as an attachment to a JIRA issue.
+
+Parameters:
+- `issueKey` (string, required): The issue key (e.g., "PROJECT-123")
+- `filePath` (string, required): Absolute local filesystem path of the file to upload
+- `filename` (string, optional): Override for the attachment filename (defaults to the basename of `filePath`)
+
+#### 10. jira_downloadAttachment
+
+Download attachment(s) from a JIRA issue, by issue key (optionally filtered by filename) or by a single attachment id. Can save to a local path and/or return the file content inline (base64 or text) — useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Confluence page).
+
+Parameters:
+- `issueKey` (string, optional): The issue key (e.g., "PROJECT-123") whose attachment(s) to download. Provide either `issueKey` or `attachmentId`.
+- `attachmentId` (string, optional): Numeric id of a single attachment to download. Provide either `attachmentId` or `issueKey`.
+- `filename` (string, optional): When using `issueKey`, download only attachments with this exact filename. If omitted, all attachments on the issue are downloaded.
+- `saveDir` (string, optional): Absolute local directory to save the attachment(s) into. The attachment filename is used as the file name. Preferred when downloading multiple files.
+- `savePath` (string, optional): Absolute local file path to save a single attachment to. Overrides `saveDir`.
+- `returnContent` (`none` | `base64` | `text`, optional): Whether to embed the file bytes in the response. Defaults to `none`. Combine with `saveDir`/`savePath` to also save to disk.
+- `maxInlineBytes` (number, optional): Maximum bytes to embed inline when `returnContent` is `base64`/`text`. Larger files are saved (if a path is given) but not embedded. Defaults to 1 MiB.

--- a/packages/jira/README.md
+++ b/packages/jira/README.md
@@ -137,6 +137,37 @@ Alternatively, you can use `JIRA_API_BASE_PATH` instead of `JIRA_HOST` to specif
 
    See [Configuration sources](#configuration-sources) for the full precedence chain.
 
+   ### Attachment filesystem access (opt-in)
+
+   By default this server is an API-only client: the attachment tools never read from or write to the local filesystem, and `jira_uploadAttachment` is **not even registered**. `jira_downloadAttachment` is always available but can only return file bytes inline (base64/text) — it cannot touch local disk.
+
+   Local filesystem access is opt-in and confined to operator-configured directories that the model cannot choose:
+
+   ```
+   # Enable each direction separately (default: false)
+   JIRA_ATTACHMENTS_UPLOAD_ENABLED=true
+   JIRA_ATTACHMENTS_DOWNLOAD_ENABLED=true
+
+   # Allowed roots (os path-separator list). Uploads may only read from these,
+   # downloads may only write into the first configured download root.
+   JIRA_ATTACHMENTS_UPLOAD_ROOTS=/srv/jira-exchange/in
+   JIRA_ATTACHMENTS_DOWNLOAD_ROOTS=/srv/jira-exchange/out
+
+   # Convenience: a single dedicated exchange directory used as both roots
+   JIRA_ATTACHMENTS_DIR=/srv/jira-exchange
+
+   # Hard per-file size limits in bytes (default: 25 MiB)
+   JIRA_ATTACHMENTS_MAX_UPLOAD_BYTES=26214400
+   JIRA_ATTACHMENTS_MAX_DOWNLOAD_BYTES=26214400
+   ```
+
+   Guardrails applied when enabled:
+   - A direction only activates when its flag is set **and** at least one root resolves; otherwise the tool stays disabled and a warning is logged.
+   - Roots are canonicalized (realpath) at startup. Requested paths are relative to a root; absolute paths and `..` segments are rejected, and a path that escapes a root through a symlinked directory is refused.
+   - Uploads reject symlinks and non-regular files (FIFOs, devices, directories).
+   - Downloads never overwrite an existing file (including a symlink) — they use an exclusive write.
+   - Both directions enforce the configured hard size limit.
+
    To create a personal access token:
   - In Jira, select your profile picture at the top right
   - Select **Personal Access Tokens**
@@ -250,22 +281,22 @@ Parameters:
 
 #### 9. jira_uploadAttachment
 
-Upload a local file as an attachment to a JIRA issue.
+Upload a local file as an attachment to a JIRA issue. Only registered when filesystem uploads are enabled (see [Attachment filesystem access](#attachment-filesystem-access-opt-in)).
 
 Parameters:
 - `issueKey` (string, required): The issue key (e.g., "PROJECT-123")
-- `filePath` (string, required): Absolute local filesystem path of the file to upload
-- `filename` (string, optional): Override for the attachment filename (defaults to the basename of `filePath`)
+- `sourcePath` (string, required): Path to the file to upload, **relative to a server-configured upload directory**. Absolute paths and `..` segments are rejected; symlinks and non-regular files are refused.
+- `filename` (string, optional): Override for the attachment filename (defaults to the basename of `sourcePath`)
 
 #### 10. jira_downloadAttachment
 
-Download attachment(s) from a JIRA issue, by issue key (optionally filtered by filename) or by a single attachment id. Can save to a local path and/or return the file content inline (base64 or text) — useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Confluence page).
+Download attachment(s) from a JIRA issue, by issue key (optionally filtered by filename) or by a single attachment id. Returns the file content inline (base64 or text) — useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Confluence page). When filesystem downloads are enabled (see [Attachment filesystem access](#attachment-filesystem-access-opt-in)), it can also save into the server-configured download directory.
 
 Parameters:
 - `issueKey` (string, optional): The issue key (e.g., "PROJECT-123") whose attachment(s) to download. Provide either `issueKey` or `attachmentId`.
 - `attachmentId` (string, optional): Numeric id of a single attachment to download. Provide either `attachmentId` or `issueKey`.
 - `filename` (string, optional): When using `issueKey`, download only attachments with this exact filename. If omitted, all attachments on the issue are downloaded.
-- `saveDir` (string, optional): Absolute local directory to save the attachment(s) into. The attachment filename is used as the file name. Preferred when downloading multiple files.
-- `savePath` (string, optional): Absolute local file path to save a single attachment to. Overrides `saveDir`.
-- `returnContent` (`none` | `base64` | `text`, optional): Whether to embed the file bytes in the response. Defaults to `none`. Combine with `saveDir`/`savePath` to also save to disk.
-- `maxInlineBytes` (number, optional): Maximum bytes to embed inline when `returnContent` is `base64`/`text`. Larger files are saved (if a path is given) but not embedded. Defaults to 1 MiB.
+- `returnContent` (`none` | `base64` | `text`, optional): Whether to embed the file bytes in the response. Defaults to `none`.
+- `maxInlineBytes` (number, optional): Maximum bytes to embed inline when `returnContent` is `base64`/`text`. Larger files are omitted from the inline content. Defaults to 1 MiB.
+- `save` (boolean, optional): Save the attachment(s) into the server-configured download directory. Requires filesystem downloads to be enabled; existing files are never overwritten. *(Only available when downloads are enabled.)*
+- `saveName` (string, optional): File name (no directories) to use when saving a single attachment; defaults to the attachment's own name. *(Only available when downloads are enabled.)*

--- a/packages/jira/src/__tests__/jira-download.test.ts
+++ b/packages/jira/src/__tests__/jira-download.test.ts
@@ -1,0 +1,108 @@
+import { JiraService } from '../jira-service.js';
+import { AttachmentService, IssueService } from '../jira-client/index.js';
+
+jest.mock('../jira-client/index.js', () => ({
+  AttachmentService: {
+    getAttachment: jest.fn(),
+  },
+  IssueService: {
+    getIssue: jest.fn(),
+  },
+  MyselfService: {},
+  SearchService: {},
+  OpenAPI: { BASE: '', TOKEN: '', VERSION: '' },
+}));
+
+function mockFetchText(text: string) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: { get: () => 'text/plain' },
+    arrayBuffer: async () => Buffer.from(text),
+  }) as unknown as typeof fetch;
+}
+
+describe('JiraService.downloadAttachments', () => {
+  let service: JiraService;
+
+  beforeEach(() => {
+    service = new JiraService('test-host', 'test-token', undefined, () => 25);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('downloads a single attachment by id using its content URL', async () => {
+    (AttachmentService.getAttachment as jest.Mock).mockResolvedValue({
+      id: '10001',
+      filename: 'report.pdf',
+      mimeType: 'application/pdf',
+      content: 'https://test-host/secure/attachment/10001/report.pdf',
+    });
+    mockFetchText('pdf-bytes');
+
+    const result = await service.downloadAttachments({ attachmentId: '10001', options: { returnContent: 'text' } });
+
+    expect(AttachmentService.getAttachment).toHaveBeenCalledWith('10001');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://test-host/secure/attachment/10001/report.pdf',
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer test-token' }) }),
+    );
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({ count: 1 });
+    expect(result.data!.attachments[0]).toMatchObject({ filename: 'report.pdf', content: 'pdf-bytes' });
+  });
+
+  it('downloads all attachments on an issue', async () => {
+    (IssueService.getIssue as jest.Mock).mockResolvedValue({
+      fields: {
+        attachment: [
+          { id: '1', filename: 'a.txt', content: 'https://test-host/a' },
+          { id: '2', filename: 'b.txt', content: 'https://test-host/b' },
+        ],
+      },
+    });
+    mockFetchText('x');
+
+    const result = await service.downloadAttachments({ issueKey: 'PROJ-1' });
+
+    expect(IssueService.getIssue).toHaveBeenCalledWith('PROJ-1', undefined, ['attachment']);
+    expect(result.success).toBe(true);
+    expect(result.data!.count).toBe(2);
+  });
+
+  it('filters issue attachments by filename', async () => {
+    (IssueService.getIssue as jest.Mock).mockResolvedValue({
+      fields: {
+        attachment: [
+          { id: '1', filename: 'a.txt', content: 'https://test-host/a' },
+          { id: '2', filename: 'b.txt', content: 'https://test-host/b' },
+        ],
+      },
+    });
+    mockFetchText('x');
+
+    const result = await service.downloadAttachments({ issueKey: 'PROJ-1', filename: 'b.txt' });
+
+    expect(result.success).toBe(true);
+    expect(result.data!.count).toBe(1);
+    expect(result.data!.attachments[0].filename).toBe('b.txt');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails when neither attachmentId nor issueKey is provided', async () => {
+    const result = await service.downloadAttachments({});
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('attachmentId or issueKey');
+  });
+
+  it('fails when an issue has no matching attachment', async () => {
+    (IssueService.getIssue as jest.Mock).mockResolvedValue({ fields: { attachment: [] } });
+
+    const result = await service.downloadAttachments({ issueKey: 'PROJ-1', filename: 'x.txt' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('No attachment named "x.txt"');
+  });
+});

--- a/packages/jira/src/__tests__/jira-download.test.ts
+++ b/packages/jira/src/__tests__/jira-download.test.ts
@@ -1,5 +1,8 @@
+import type { AttachmentGatewaySide } from '@atlassian-dc-mcp/common';
 import { JiraService } from '../jira-service.js';
 import { AttachmentService, IssueService } from '../jira-client/index.js';
+
+const DISABLED_DOWNLOAD: AttachmentGatewaySide = { enabled: false, roots: [], maxBytes: 25 * 1024 * 1024 };
 
 jest.mock('../jira-client/index.js', () => ({
   AttachmentService: {
@@ -42,7 +45,7 @@ describe('JiraService.downloadAttachments', () => {
     });
     mockFetchText('pdf-bytes');
 
-    const result = await service.downloadAttachments({ attachmentId: '10001', options: { returnContent: 'text' } });
+    const result = await service.downloadAttachments({ attachmentId: '10001', returnContent: 'text', downloadSide: DISABLED_DOWNLOAD });
 
     expect(AttachmentService.getAttachment).toHaveBeenCalledWith('10001');
     expect(global.fetch).toHaveBeenCalledWith(
@@ -65,7 +68,7 @@ describe('JiraService.downloadAttachments', () => {
     });
     mockFetchText('x');
 
-    const result = await service.downloadAttachments({ issueKey: 'PROJ-1' });
+    const result = await service.downloadAttachments({ issueKey: 'PROJ-1', downloadSide: DISABLED_DOWNLOAD });
 
     expect(IssueService.getIssue).toHaveBeenCalledWith('PROJ-1', undefined, ['attachment']);
     expect(result.success).toBe(true);
@@ -83,7 +86,7 @@ describe('JiraService.downloadAttachments', () => {
     });
     mockFetchText('x');
 
-    const result = await service.downloadAttachments({ issueKey: 'PROJ-1', filename: 'b.txt' });
+    const result = await service.downloadAttachments({ issueKey: 'PROJ-1', filename: 'b.txt', downloadSide: DISABLED_DOWNLOAD });
 
     expect(result.success).toBe(true);
     expect(result.data!.count).toBe(1);
@@ -92,7 +95,7 @@ describe('JiraService.downloadAttachments', () => {
   });
 
   it('fails when neither attachmentId nor issueKey is provided', async () => {
-    const result = await service.downloadAttachments({});
+    const result = await service.downloadAttachments({ downloadSide: DISABLED_DOWNLOAD });
     expect(result.success).toBe(false);
     expect(result.error).toContain('attachmentId or issueKey');
   });
@@ -100,7 +103,7 @@ describe('JiraService.downloadAttachments', () => {
   it('fails when an issue has no matching attachment', async () => {
     (IssueService.getIssue as jest.Mock).mockResolvedValue({ fields: { attachment: [] } });
 
-    const result = await service.downloadAttachments({ issueKey: 'PROJ-1', filename: 'x.txt' });
+    const result = await service.downloadAttachments({ issueKey: 'PROJ-1', filename: 'x.txt', downloadSide: DISABLED_DOWNLOAD });
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('No attachment named "x.txt"');

--- a/packages/jira/src/__tests__/jira-upload.test.ts
+++ b/packages/jira/src/__tests__/jira-upload.test.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AttachmentGatewaySide } from '@atlassian-dc-mcp/common';
+import { JiraService } from '../jira-service.js';
+import { IssueService } from '../jira-client/index.js';
+
+jest.mock('../jira-client/index.js', () => ({
+  AttachmentService: {},
+  IssueService: {
+    addAttachment: jest.fn(),
+  },
+  MyselfService: {},
+  SearchService: {},
+  OpenAPI: { BASE: '', TOKEN: '', VERSION: '' },
+}));
+
+describe('JiraService.uploadAttachment', () => {
+  let service: JiraService;
+  let root: string;
+  const uploadSide = (): AttachmentGatewaySide => ({ enabled: true, roots: [fs.realpathSync(root)], maxBytes: 1024 });
+
+  beforeEach(() => {
+    service = new JiraService('test-host', 'test-token', undefined, () => 25);
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mcp-jup-'));
+    jest.clearAllMocks();
+    (IssueService.addAttachment as jest.Mock).mockResolvedValue([{ id: '1', filename: 'a.txt' }]);
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  it('uploads a file resolved within the upload root', async () => {
+    fs.writeFileSync(path.join(root, 'a.txt'), 'hello');
+
+    const result = await service.uploadAttachment('PROJ-1', 'a.txt', uploadSide());
+
+    expect(result.success).toBe(true);
+    expect(IssueService.addAttachment).toHaveBeenCalledTimes(1);
+    const [issueKey, formData] = (IssueService.addAttachment as jest.Mock).mock.calls[0];
+    expect(issueKey).toBe('PROJ-1');
+    expect(formData.file.name).toBe('a.txt');
+  });
+
+  it('rejects an absolute path outside the root', async () => {
+    const result = await service.uploadAttachment('PROJ-1', '/etc/passwd', uploadSide());
+    expect(result.success).toBe(false);
+    expect(IssueService.addAttachment).not.toHaveBeenCalled();
+  });
+
+  it('rejects a symlink inside the root', async () => {
+    const target = path.join(root, 'real.txt');
+    fs.writeFileSync(target, 'secret');
+    fs.symlinkSync(target, path.join(root, 'link.txt'));
+
+    const result = await service.uploadAttachment('PROJ-1', 'link.txt', uploadSide());
+    expect(result.success).toBe(false);
+    expect(IssueService.addAttachment).not.toHaveBeenCalled();
+  });
+
+  it('rejects a file over the size limit', async () => {
+    fs.writeFileSync(path.join(root, 'big.txt'), 'x'.repeat(2048));
+
+    const result = await service.uploadAttachment('PROJ-1', 'big.txt', uploadSide());
+    expect(result.success).toBe(false);
+    expect(IssueService.addAttachment).not.toHaveBeenCalled();
+  });
+});

--- a/packages/jira/src/index.ts
+++ b/packages/jira/src/index.ts
@@ -107,4 +107,14 @@ server.tool(
   }
 );
 
+server.tool(
+  "jira_uploadAttachment",
+  `Upload a local file as an attachment to a JIRA issue in the ${jiraInstanceType}`,
+  jiraToolSchemas.uploadAttachment,
+  async ({ issueKey, filePath, filename }) => {
+    const result = await jiraService.uploadAttachment(issueKey, filePath, filename);
+    return formatToolResponse(result);
+  }
+);
+
 await connectServer(server);

--- a/packages/jira/src/index.ts
+++ b/packages/jira/src/index.ts
@@ -1,6 +1,6 @@
-import { connectServer, createMcpServer, formatToolResponse, initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
+import { connectServer, createMcpServer, formatToolResponse, initializeRuntimeConfig, resolveAttachmentGateway } from '@atlassian-dc-mcp/common';
 import { JiraService, jiraToolSchemas } from './jira-service.js';
-import { getDefaultPageSize, getJiraRuntimeConfig } from './config.js';
+import { getDefaultPageSize, getJiraRuntimeConfig, JIRA_PRODUCT } from './config.js';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
@@ -117,26 +117,46 @@ server.tool(
   }
 );
 
-server.tool(
-  "jira_uploadAttachment",
-  `Upload a local file as an attachment to a JIRA issue in the ${jiraInstanceType}`,
-  jiraToolSchemas.uploadAttachment,
-  async ({ issueKey, filePath, filename }) => {
-    const result = await jiraService.uploadAttachment(issueKey, filePath, filename);
-    return formatToolResponse(result);
-  }
-);
+const attachmentGateway = resolveAttachmentGateway(JIRA_PRODUCT);
 
+// Filesystem-reading upload is only registered when the operator explicitly enables it.
+if (attachmentGateway.upload.enabled) {
+  server.tool(
+    "jira_uploadAttachment",
+    `Upload a local file as an attachment to a JIRA issue in the ${jiraInstanceType}. The file must live under the server-configured upload directory; the path is given relative to that directory.`,
+    jiraToolSchemas.uploadAttachment,
+    async ({ issueKey, sourcePath, filename }) => {
+      const result = await jiraService.uploadAttachment(issueKey, sourcePath, attachmentGateway.upload, filename);
+      return formatToolResponse(result);
+    }
+  );
+}
+
+// Download always returns content inline (no filesystem access). Saving to disk is
+// only offered when the operator enables it, and is confined to the configured directory.
+const downloadSaveEnabled = attachmentGateway.download.enabled;
 server.tool(
   "jira_downloadAttachment",
-  `Download attachment(s) from a JIRA issue in the ${jiraInstanceType}, by issue key (optionally filtered by filename) or by a single attachment id. Can save to a local path and/or return the file content inline (base64 or text). Useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Confluence page).`,
-  jiraToolSchemas.downloadAttachment,
-  async ({ issueKey, attachmentId, filename, saveDir, savePath, returnContent, maxInlineBytes }) => {
+  `Download attachment(s) from a JIRA issue in the ${jiraInstanceType}, by issue key (optionally filtered by filename) or by a single attachment id. Returns the file content inline (base64 or text). Useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Confluence page).${downloadSaveEnabled ? ' Can also save into the server-configured download directory; existing files are never overwritten.' : ' Saving to local disk is disabled on this server.'}`,
+  { ...jiraToolSchemas.downloadAttachment, ...(downloadSaveEnabled ? jiraToolSchemas.downloadAttachmentSaveFields : {}) },
+  async ({ issueKey, attachmentId, filename, returnContent, maxInlineBytes, save, saveName }: {
+    issueKey?: string;
+    attachmentId?: string;
+    filename?: string;
+    returnContent?: 'none' | 'base64' | 'text';
+    maxInlineBytes?: number;
+    save?: boolean;
+    saveName?: string;
+  }) => {
     const result = await jiraService.downloadAttachments({
       issueKey,
       attachmentId,
       filename,
-      options: { saveDir, savePath, returnContent, maxInlineBytes },
+      save,
+      saveName,
+      returnContent,
+      maxInlineBytes,
+      downloadSide: attachmentGateway.download,
     });
     return formatToolResponse(result);
   }

--- a/packages/jira/src/index.ts
+++ b/packages/jira/src/index.ts
@@ -117,4 +117,19 @@ server.tool(
   }
 );
 
+server.tool(
+  "jira_downloadAttachment",
+  `Download attachment(s) from a JIRA issue in the ${jiraInstanceType}, by issue key (optionally filtered by filename) or by a single attachment id. Can save to a local path and/or return the file content inline (base64 or text). Useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Confluence page).`,
+  jiraToolSchemas.downloadAttachment,
+  async ({ issueKey, attachmentId, filename, saveDir, savePath, returnContent, maxInlineBytes }) => {
+    const result = await jiraService.downloadAttachments({
+      issueKey,
+      attachmentId,
+      filename,
+      options: { saveDir, savePath, returnContent, maxInlineBytes },
+    });
+    return formatToolResponse(result);
+  }
+);
+
 await connectServer(server);

--- a/packages/jira/src/jira-service.ts
+++ b/packages/jira/src/jira-service.ts
@@ -1,3 +1,6 @@
+import { File } from 'node:buffer';
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
 import { z } from 'zod';
 import { handleApiOperation, resolveOpenApiBase } from '@atlassian-dc-mcp/common';
 import { IssueService, MyselfService, OpenAPI, SearchService } from './jira-client/index.js';
@@ -39,6 +42,7 @@ export class JiraService {
     });
     OpenAPI.TOKEN = resolveToken(token, 'Missing required environment variable: JIRA_API_TOKEN');
     OpenAPI.VERSION = '2';
+    OpenAPI.HEADERS = { 'X-Atlassian-Token': 'no-check' };
     this.getPageSize = getPageSize;
   }
 
@@ -145,6 +149,17 @@ export class JiraService {
     }, 'Error transitioning issue');
   }
 
+  async uploadAttachment(issueKey: string, filePath: string, filename?: string) {
+    const buffer = await readFile(filePath);
+    const name = filename || basename(filePath);
+    const file = new File([buffer], name);
+    // IssueService types formData as Blob, but the API expects { file } — getFormData handles File via isBlob()
+    return handleApiOperation(
+      () => IssueService.addAttachment(issueKey, { file } as any),
+      'Error uploading attachment',
+    );
+  }
+
   async validateSetup(): Promise<void> {
     await MyselfService.getUser();
   }
@@ -198,5 +213,10 @@ export const jiraToolSchemas = {
     issueKey: z.string().describe("JIRA issue key (e.g., PROJ-123)"),
     transitionId: z.string().describe("The ID of the transition to perform. Use jira_getTransitions to find available transitions and their IDs."),
     fields: z.record(z.any()).optional().describe("Optional fields required by the transition screen. Use jira_getTransitions to see which fields are available for each transition.")
+  },
+  uploadAttachment: {
+    issueKey: z.string().describe("JIRA issue key (e.g., PROJ-123)"),
+    filePath: z.string().describe("Absolute local filesystem path of the file to upload"),
+    filename: z.string().optional().describe("Override for the attachment filename (defaults to the basename of filePath)")
   }
 };

--- a/packages/jira/src/jira-service.ts
+++ b/packages/jira/src/jira-service.ts
@@ -2,7 +2,15 @@ import { File } from 'node:buffer';
 import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { z } from 'zod';
-import { downloadAttachment, handleApiOperation, resolveOpenApiBase, type AttachmentDownloadOptions } from '@atlassian-dc-mcp/common';
+import {
+  downloadAttachment,
+  handleApiOperation,
+  resolveDownloadDestination,
+  resolveOpenApiBase,
+  resolveUploadSource,
+  type AttachmentContentEncoding,
+  type AttachmentGatewaySide,
+} from '@atlassian-dc-mcp/common';
 import { AttachmentService, IssueService, MyselfService, OpenAPI, SearchService } from './jira-client/index.js';
 import { request as __request } from './jira-client/core/request.js';
 import type { StringList } from './jira-client/models/StringList.js';
@@ -183,15 +191,15 @@ export class JiraService {
     }, 'Error transitioning issue');
   }
 
-  async uploadAttachment(issueKey: string, filePath: string, filename?: string) {
-    const buffer = await readFile(filePath);
-    const name = filename || basename(filePath);
-    const file = new File([buffer], name);
-    // IssueService types formData as Blob, but the API expects { file } — getFormData handles File via isBlob()
-    return handleApiOperation(
-      () => IssueService.addAttachment(issueKey, { file } as any),
-      'Error uploading attachment',
-    );
+  async uploadAttachment(issueKey: string, sourcePath: string, uploadSide: AttachmentGatewaySide, filename?: string) {
+    return handleApiOperation(async () => {
+      const { absolutePath } = await resolveUploadSource({ requestedPath: sourcePath, side: uploadSide });
+      const buffer = await readFile(absolutePath);
+      const name = filename || basename(absolutePath);
+      const file = new File([buffer], name);
+      // IssueService types formData as Blob, but the API expects { file } — getFormData handles File via isBlob()
+      return IssueService.addAttachment(issueKey, { file } as any);
+    }, 'Error uploading attachment');
   }
 
   /**
@@ -200,29 +208,55 @@ export class JiraService {
    * @param params.attachmentId Download a single attachment by its numeric id
    * @param params.issueKey Download attachments from this issue (optionally filtered by filename)
    * @param params.filename When using issueKey, download only attachments with this exact filename
-   * @param params.options Save-to-disk and inline-content options (see AttachmentDownloadOptions)
+   * @param params.save Whether to write the attachment(s) to the operator-configured download directory
+   * @param params.saveName Optional file name (basename only) when saving a single attachment
+   * @param params.returnContent Whether/how to embed the bytes inline in the response
+   * @param params.maxInlineBytes Inline embedding cap
+   * @param params.downloadSide Resolved download gateway (roots, size limit, enabled flag)
    */
   async downloadAttachments(params: {
     attachmentId?: string;
     issueKey?: string;
     filename?: string;
-    options?: AttachmentDownloadOptions;
+    save?: boolean;
+    saveName?: string;
+    returnContent?: AttachmentContentEncoding;
+    maxInlineBytes?: number;
+    downloadSide: AttachmentGatewaySide;
   }) {
     return handleApiOperation(async () => {
+      if (params.save && !params.downloadSide.enabled) {
+        throw new Error(
+          'Saving attachments to disk is disabled on this server. Enable it with ' +
+            'JIRA_ATTACHMENTS_DOWNLOAD_ENABLED and configure a download directory.',
+        );
+      }
       const beans = await this.resolveAttachmentBeans(params);
+      const multiple = beans.length > 1;
       const attachments = [];
       for (const bean of beans) {
         const url = bean?.content;
         if (!url) {
           throw new Error(`Attachment "${bean?.filename ?? bean?.id}" has no download URL`);
         }
+        const filename = bean?.filename ?? String(bean?.id ?? 'attachment');
+        let destination: string | undefined;
+        if (params.save) {
+          const requestedName = multiple ? filename : params.saveName ?? filename;
+          destination = await resolveDownloadDestination({ requestedName, side: params.downloadSide });
+        }
         attachments.push(
           await downloadAttachment({
             url,
             token: this.tokenProvider,
-            filename: bean?.filename ?? String(bean?.id ?? 'attachment'),
+            filename,
             mediaType: bean?.mimeType,
-            options: params.options,
+            options: {
+              destination,
+              returnContent: params.returnContent,
+              maxInlineBytes: params.maxInlineBytes,
+              maxDownloadBytes: params.downloadSide.maxBytes,
+            },
           }),
         );
       }
@@ -317,16 +351,18 @@ export const jiraToolSchemas = {
   },
   uploadAttachment: {
     issueKey: z.string().describe("JIRA issue key (e.g., PROJ-123)"),
-    filePath: z.string().describe("Absolute local filesystem path of the file to upload"),
-    filename: z.string().optional().describe("Override for the attachment filename (defaults to the basename of filePath)")
+    sourcePath: z.string().describe("Path to the file to upload, relative to a server-configured attachment upload directory. Absolute paths and '..' segments are rejected; symlinks and non-regular files are refused."),
+    filename: z.string().optional().describe("Override for the attachment filename (defaults to the basename of sourcePath)")
   },
   downloadAttachment: {
     issueKey: z.string().optional().describe("JIRA issue key (e.g., PROJ-123) whose attachment(s) to download. Provide either issueKey or attachmentId."),
     attachmentId: z.string().optional().describe("Numeric id of a single attachment to download. Provide either attachmentId or issueKey."),
     filename: z.string().optional().describe("When using issueKey, download only attachments with this exact filename. If omitted, all attachments on the issue are downloaded."),
-    saveDir: z.string().optional().describe("Absolute local directory to save the attachment(s) into. The attachment filename is used as the file name. Preferred when downloading multiple files."),
-    savePath: z.string().optional().describe("Absolute local file path to save a single attachment to. Overrides saveDir. Only meaningful when downloading a single attachment."),
-    returnContent: z.enum(['none', 'base64', 'text']).optional().describe("Whether to embed the file bytes in the response: 'none' (default), 'base64' for binary, or 'text' for UTF-8 text. Combine with saveDir/savePath to also save to disk."),
-    maxInlineBytes: z.number().optional().describe("Maximum bytes to embed inline when returnContent is base64/text. Larger files are saved (if a path is given) but not embedded. Defaults to 1 MiB.")
+    returnContent: z.enum(['none', 'base64', 'text']).optional().describe("Whether to embed the file bytes in the response: 'none' (default), 'base64' for binary, or 'text' for UTF-8 text."),
+    maxInlineBytes: z.number().optional().describe("Maximum bytes to embed inline when returnContent is base64/text. Larger files are omitted from the inline content. Defaults to 1 MiB.")
+  },
+  downloadAttachmentSaveFields: {
+    save: z.boolean().optional().describe("Save the attachment(s) into the server-configured download directory. Requires disk downloads to be enabled on the server."),
+    saveName: z.string().optional().describe("Optional file name (no directories) to use when saving a single attachment; defaults to the attachment's own name. Existing files are never overwritten.")
   }
 };

--- a/packages/jira/src/jira-service.ts
+++ b/packages/jira/src/jira-service.ts
@@ -2,8 +2,8 @@ import { File } from 'node:buffer';
 import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { z } from 'zod';
-import { handleApiOperation, resolveOpenApiBase } from '@atlassian-dc-mcp/common';
-import { IssueService, MyselfService, OpenAPI, SearchService } from './jira-client/index.js';
+import { downloadAttachment, handleApiOperation, resolveOpenApiBase, type AttachmentDownloadOptions } from '@atlassian-dc-mcp/common';
+import { AttachmentService, IssueService, MyselfService, OpenAPI, SearchService } from './jira-client/index.js';
 import type { StringList } from './jira-client/models/StringList.js';
 import { getDefaultPageSize, getMissingConfig, JIRA_PRODUCT } from './config.js';
 
@@ -27,6 +27,7 @@ function resolveToken(token: string | (() => string | undefined), missingTokenMe
 
 export class JiraService {
   private readonly getPageSize: () => number;
+  private readonly tokenProvider: string | (() => string | undefined);
 
   constructor(
     host: string | undefined,
@@ -43,6 +44,7 @@ export class JiraService {
     OpenAPI.TOKEN = resolveToken(token, 'Missing required environment variable: JIRA_API_TOKEN');
     OpenAPI.VERSION = '2';
     OpenAPI.HEADERS = { 'X-Atlassian-Token': 'no-check' };
+    this.tokenProvider = token;
     this.getPageSize = getPageSize;
   }
 
@@ -160,6 +162,67 @@ export class JiraService {
     );
   }
 
+  /**
+   * Download attachments from a JIRA issue, or a single attachment by its id.
+   * Exactly one of `attachmentId` or `issueKey` must be provided.
+   * @param params.attachmentId Download a single attachment by its numeric id
+   * @param params.issueKey Download attachments from this issue (optionally filtered by filename)
+   * @param params.filename When using issueKey, download only attachments with this exact filename
+   * @param params.options Save-to-disk and inline-content options (see AttachmentDownloadOptions)
+   */
+  async downloadAttachments(params: {
+    attachmentId?: string;
+    issueKey?: string;
+    filename?: string;
+    options?: AttachmentDownloadOptions;
+  }) {
+    return handleApiOperation(async () => {
+      const beans = await this.resolveAttachmentBeans(params);
+      const attachments = [];
+      for (const bean of beans) {
+        const url = bean?.content;
+        if (!url) {
+          throw new Error(`Attachment "${bean?.filename ?? bean?.id}" has no download URL`);
+        }
+        attachments.push(
+          await downloadAttachment({
+            url,
+            token: this.tokenProvider,
+            filename: bean?.filename ?? String(bean?.id ?? 'attachment'),
+            mediaType: bean?.mimeType,
+            options: params.options,
+          }),
+        );
+      }
+      return { count: attachments.length, attachments };
+    }, 'Error downloading attachment');
+  }
+
+  private async resolveAttachmentBeans(params: {
+    attachmentId?: string;
+    issueKey?: string;
+    filename?: string;
+  }): Promise<Array<Record<string, any>>> {
+    if (params.attachmentId) {
+      const bean = await AttachmentService.getAttachment(params.attachmentId);
+      return [bean as Record<string, any>];
+    }
+    if (!params.issueKey) {
+      throw new Error('Either attachmentId or issueKey must be provided');
+    }
+    const issue = await IssueService.getIssue(params.issueKey, undefined, toIssueFieldSelection(['attachment']));
+    const all = (((issue as any)?.fields?.attachment) ?? []) as Array<Record<string, any>>;
+    const filtered = params.filename ? all.filter((a) => a?.filename === params.filename) : all;
+    if (filtered.length === 0) {
+      throw new Error(
+        params.filename
+          ? `No attachment named "${params.filename}" found on issue ${params.issueKey}`
+          : `No attachments found on issue ${params.issueKey}`,
+      );
+    }
+    return filtered;
+  }
+
   async validateSetup(): Promise<void> {
     await MyselfService.getUser();
   }
@@ -218,5 +281,14 @@ export const jiraToolSchemas = {
     issueKey: z.string().describe("JIRA issue key (e.g., PROJ-123)"),
     filePath: z.string().describe("Absolute local filesystem path of the file to upload"),
     filename: z.string().optional().describe("Override for the attachment filename (defaults to the basename of filePath)")
+  },
+  downloadAttachment: {
+    issueKey: z.string().optional().describe("JIRA issue key (e.g., PROJ-123) whose attachment(s) to download. Provide either issueKey or attachmentId."),
+    attachmentId: z.string().optional().describe("Numeric id of a single attachment to download. Provide either attachmentId or issueKey."),
+    filename: z.string().optional().describe("When using issueKey, download only attachments with this exact filename. If omitted, all attachments on the issue are downloaded."),
+    saveDir: z.string().optional().describe("Absolute local directory to save the attachment(s) into. The attachment filename is used as the file name. Preferred when downloading multiple files."),
+    savePath: z.string().optional().describe("Absolute local file path to save a single attachment to. Overrides saveDir. Only meaningful when downloading a single attachment."),
+    returnContent: z.enum(['none', 'base64', 'text']).optional().describe("Whether to embed the file bytes in the response: 'none' (default), 'base64' for binary, or 'text' for UTF-8 text. Combine with saveDir/savePath to also save to disk."),
+    maxInlineBytes: z.number().optional().describe("Maximum bytes to embed inline when returnContent is base64/text. Larger files are saved (if a path is given) but not embedded. Defaults to 1 MiB.")
   }
 };


### PR DESCRIPTION
Adds attachment support to the Jira MCP server.

## Tools

### `jira_uploadAttachment`
Uploads a local file as an attachment to a Jira issue via the generated `IssueService.addAttachment`.
- Sets `X-Atlassian-Token: no-check` globally (required for multipart POSTs).
- Uses `File` from `node:buffer` for Node 18.13+ compatibility.

### `jira_downloadAttachment`
Downloads attachment(s) either by `issueKey` (optionally filtered by `filename`, or all attachments on the issue) or by a single `attachmentId`.
- `saveDir` / `savePath` — write the file(s) to disk.
- `returnContent` (`none` | `base64` | `text`, default `none`) — embed bytes inline so the AI can inspect the file directly; `maxInlineBytes` caps inline size (default 1 MiB).
- Uses the attachment's absolute `content` URL from the Jira API.

Together these enable round-trips like downloading a file from Jira and re-uploading it to a Confluence page.

## Shared helper
Extracts `downloadAttachment` into `@atlassian-dc-mcp/common` (`packages/common/src/attachment-download.ts`) — authenticates with a Bearer token, sends `X-Atlassian-Token: nocheck`, guards against path traversal, and buffers the response for optional inline return.

> Note: the same `common` helper is added identically in #34 (Confluence). The files are byte-identical, so the two PRs merge cleanly in either order.

## Tests
`common` (103), `jira` (35) — all passing. README updated for both tools.