### PR TITLE
fix(bitbucket): clarify that reviewers param requires 'name', not 'slug'

### DIFF
--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -852,7 +852,7 @@ export const bitbucketToolSchemas = {
     description: z.string().optional().describe("The pull request description"),
     fromRefId: z.string().describe("The source branch reference ID (e.g., 'refs/heads/feature-branch')"),
     toRefId: z.string().describe("The destination branch reference ID (e.g., 'refs/heads/main')"),
-    reviewers: z.array(z.string()).optional().describe("Optional array of reviewer usernames"),
+    reviewers: z.array(z.string()).optional().describe("Optional array of reviewer usernames (use the 'name' field from Bitbucket user objects, not 'slug')"),
     output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
   },
   updatePullRequest: {
@@ -862,7 +862,7 @@ export const bitbucketToolSchemas = {
     version: z.number().describe("The current version of the pull request (required for optimistic locking). Obtain this by calling bitbucket_getPullRequest first."),
     title: z.string().optional().describe("The new title for the pull request"),
     description: z.string().optional().describe("The new description for the pull request"),
-    reviewers: z.array(z.string()).optional().describe("Optional array of reviewer usernames to set"),
+    reviewers: z.array(z.string()).optional().describe("Optional array of reviewer usernames to set (use the 'name' field from Bitbucket user objects, not 'slug')"),
     output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
   },
   getRequiredReviewers: {


### PR DESCRIPTION
LLMs (at least Copilot with Claude) typically try the `slug` field first when passing reviewers to `createPullRequest`/`updatePullRequest`, which Bitbucket DC rejects. This updates the Zod schema descriptions for the `reviewers` parameter in both tool schemas to make it explicit that the `name` field from Bitbucket user objects should be used, not `slug`.

### Changes

- `bitbucketToolSchemas.createPullRequest.reviewers` — description now says `(use the 'name' field from Bitbucket user objects, not 'slug')`
- `bitbucketToolSchemas.updatePullRequest.reviewers` — same

### Why

The `createPullRequest()` and `updatePullRequest()` methods map reviewer usernames to `{ user: { name: username } }`. Bitbucket DC's API requires the `name` field (which is the user's login/username), but LLMs commonly pick `slug` instead because it looks like a username too. Making the schema description explicit fixes this on the first attempt.