### PR TITLE
feat(bitbucket): post comments as tasks and update PR comments

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -16,6 +16,7 @@ jest.mock('../bitbucket-client/index.js', () => ({
   PullRequestsService: {
     streamRawDiff2: jest.fn(),
     createComment2: jest.fn(),
+    updateComment2: jest.fn(),
     streamChanges1: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
@@ -1879,6 +1880,177 @@ describe('BitbucketService', () => {
 
       const missingVars = BitbucketService.validateConfig();
       expect(missingVars).toEqual([]);
+    });
+  });
+
+  describe('updatePullRequestComment', () => {
+    it('should resolve a task by sending state RESOLVED with the version', async () => {
+      const mockComment = { id: 500, version: 2, state: 'RESOLVED', text: 'Task body' };
+      (PullRequestsService.updateComment2 as jest.Mock).mockResolvedValue(mockComment);
+
+      const result = await bitbucketService.updatePullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        '500',      // commentId
+        1,          // version
+        undefined,  // text
+        'RESOLVED'  // state
+      );
+
+      expect(result.success).toBe(true);
+      expect(PullRequestsService.updateComment2).toHaveBeenCalledWith(
+        mockProjectKey,
+        '500',
+        mockPullRequestId,
+        mockRepositorySlug,
+        { version: 1, state: 'RESOLVED' }
+      );
+    });
+
+    it('should edit the comment text without changing state or severity', async () => {
+      const mockComment = { id: 501, version: 3, text: 'Edited text' };
+      (PullRequestsService.updateComment2 as jest.Mock).mockResolvedValue(mockComment);
+
+      await bitbucketService.updatePullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        '501',
+        2,
+        'Edited text'
+      );
+
+      expect(PullRequestsService.updateComment2).toHaveBeenCalledWith(
+        mockProjectKey,
+        '501',
+        mockPullRequestId,
+        mockRepositorySlug,
+        { version: 2, text: 'Edited text' }
+      );
+    });
+
+    it('should support combining text, state, and severity in a single update', async () => {
+      const mockComment = { id: 502, version: 4, text: 'New body', state: 'RESOLVED', severity: 'BLOCKER' };
+      (PullRequestsService.updateComment2 as jest.Mock).mockResolvedValue(mockComment);
+
+      await bitbucketService.updatePullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        '502',
+        3,
+        'New body',
+        'RESOLVED',
+        'BLOCKER'
+      );
+
+      expect(PullRequestsService.updateComment2).toHaveBeenCalledWith(
+        mockProjectKey,
+        '502',
+        mockPullRequestId,
+        mockRepositorySlug,
+        { version: 3, text: 'New body', state: 'RESOLVED', severity: 'BLOCKER' }
+      );
+    });
+
+    it('should propagate API errors', async () => {
+      (PullRequestsService.updateComment2 as jest.Mock).mockRejectedValue(new Error('Conflict'));
+
+      const result = await bitbucketService.updatePullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        '503',
+        1,
+        undefined,
+        'RESOLVED'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Conflict');
+    });
+  });
+
+  describe('postPullRequestComment - severity flag', () => {
+    it('should include severity: BLOCKER in the request body when severity is BLOCKER', async () => {
+      const mockComment = { id: 200, text: 'Task comment', author: { displayName: 'Test User' } };
+      (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue(mockComment);
+
+      const result = await bitbucketService.postPullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        'Task comment',
+        undefined,  // parentId
+        undefined,  // filePath
+        undefined,  // line
+        undefined,  // lineType
+        undefined,  // pending
+        'BLOCKER'   // severity
+      );
+
+      expect(result.success).toBe(true);
+      expect(PullRequestsService.createComment2).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        { text: 'Task comment', severity: 'BLOCKER' }
+      );
+    });
+
+    it('should NOT include severity in the request body when severity is omitted', async () => {
+      const mockComment = { id: 201, text: 'Normal comment', author: { displayName: 'Test User' } };
+      (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue(mockComment);
+
+      await bitbucketService.postPullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        'Normal comment'
+      );
+
+      expect(PullRequestsService.createComment2).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        { text: 'Normal comment' } // no severity field
+      );
+    });
+
+    it('should support severity BLOCKER combined with a file/line anchor', async () => {
+      const mockComment = { id: 202, text: 'Inline task', author: { displayName: 'Test User' } };
+      (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue(mockComment);
+
+      await bitbucketService.postPullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        'Inline task',
+        undefined,      // parentId
+        'src/index.ts', // filePath
+        10,             // line
+        'ADDED',        // lineType
+        undefined,      // pending
+        'BLOCKER'       // severity
+      );
+
+      expect(PullRequestsService.createComment2).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        {
+          text: 'Inline task',
+          severity: 'BLOCKER',
+          anchor: {
+            path: 'src/index.ts',
+            diffType: 'EFFECTIVE',
+            line: 10,
+            lineType: 'ADDED',
+            fileType: 'TO'
+          }
+        }
+      );
     });
   });
 

--- a/packages/bitbucket/src/__tests__/bitbucket-token-optimization.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-token-optimization.test.ts
@@ -390,7 +390,7 @@ describe('BitbucketService token optimization paths', () => {
       };
       (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue(mockComment);
 
-      const result = await service.postPullRequestComment('TEST', 'repo', '123', 'Raw comment', undefined, undefined, undefined, undefined, undefined, 'full');
+      const result = await service.postPullRequestComment('TEST', 'repo', '123', 'Raw comment', undefined, undefined, undefined, undefined, undefined, undefined, 'full');
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(mockComment);

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -306,6 +306,7 @@ export class BitbucketService {
    * @param pending Optional flag to create a pending (draft) comment, not visible to others until a review is submitted.
    *   Only works when filePath is provided (file-level or inline comments).
    *   Top-level PR comments (no filePath) are always posted live regardless of this flag.
+   * @param severity Optional severity for the comment. 'BLOCKER' posts the comment as a task that must be resolved before the PR can be merged. Defaults to 'NORMAL' (regular comment) when omitted.
    * @returns Promise with created comment data
    */
   async postPullRequestComment(
@@ -318,6 +319,7 @@ export class BitbucketService {
     line?: number,
     lineType?: 'ADDED' | 'REMOVED' | 'CONTEXT',
     pending?: boolean,
+    severity?: 'NORMAL' | 'BLOCKER',
     output: BitbucketMutationOutputMode = 'ack'
   ) {
     projectKey = projectKey.toUpperCase();
@@ -325,6 +327,10 @@ export class BitbucketService {
     const comment: any = {
       text
     };
+
+    if (severity) {
+      comment.severity = severity;
+    }
 
     // Mark comment as pending (draft) — not visible to others until review is submitted
     // Note: Bitbucket DC uses state:'PENDING' not pending:true
@@ -360,6 +366,69 @@ export class BitbucketService {
         comment
       ),
       'Error posting pull request comment'
+    );
+
+    if (result.success && result.data && output !== 'full') {
+      return {
+        ...result,
+        data: shapePullRequestCommentAck(result.data),
+      };
+    }
+
+    return result;
+  }
+
+  /**
+   * Update an existing pull request comment. Use this to edit text, change severity, or change state.
+   * On a BLOCKER (task) comment, setting state to 'RESOLVED' ticks the task. Note: this is NOT the same
+   * as the thread-level "Resolve" button on regular comment threads — that operates on CommentThread.resolved
+   * and is a separate concept not exposed by this endpoint.
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param pullRequestId The pull request ID
+   * @param commentId The comment ID to update
+   * @param version The current version of the comment (required for optimistic locking)
+   * @param text Optional new comment text
+   * @param state Optional new state. On a BLOCKER comment, 'RESOLVED' ticks the task and 'OPEN' un-ticks it.
+   * @param severity Optional new severity. 'BLOCKER' converts a comment into a task, 'NORMAL' converts a task back to a regular comment.
+   * @returns Promise with updated comment data
+   */
+  async updatePullRequestComment(
+    projectKey: string,
+    repositorySlug: string,
+    pullRequestId: string,
+    commentId: string,
+    version: number,
+    text?: string,
+    state?: 'OPEN' | 'RESOLVED',
+    severity?: 'NORMAL' | 'BLOCKER',
+    output: BitbucketMutationOutputMode = 'ack'
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const comment: any = { version };
+
+    if (text !== undefined) {
+      comment.text = text;
+    }
+
+    if (state) {
+      comment.state = state;
+    }
+
+    if (severity) {
+      comment.severity = severity;
+    }
+
+    const result = await handleApiOperation(
+      () => PullRequestsService.updateComment2(
+        projectKey,
+        commentId,
+        pullRequestId,
+        repositorySlug,
+        comment
+      ),
+      'Error updating pull request comment'
     );
 
     if (result.success && result.data && output !== 'full') {
@@ -819,6 +888,18 @@ export const bitbucketToolSchemas = {
     line: z.number().optional().describe("Line number for line-specific comments"),
     lineType: z.enum(['ADDED', 'REMOVED', 'CONTEXT']).optional().describe("Line type for line comments"),
     pending: z.boolean().optional().describe("If true, creates a pending (draft) comment not visible to others until the review is submitted via bitbucket_submitPullRequestReview. Only works when filePath is provided — top-level PR comments (no filePath) are always posted live."),
+    severity: z.enum(['NORMAL', 'BLOCKER']).optional().describe("Comment severity. Use 'BLOCKER' to post the comment as a task that must be resolved before the PR can be merged. Defaults to 'NORMAL' (regular comment)."),
+    output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
+  },
+  updatePullRequestComment: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID"),
+    commentId: z.string().describe("The ID of the comment to update"),
+    version: z.number().describe("The current version of the comment, required for optimistic locking. Get it from bitbucket_getPR_CommentsAndAction or from the response of the original post/update."),
+    text: z.string().optional().describe("New comment text. Omit to leave unchanged."),
+    state: z.enum(['OPEN', 'RESOLVED']).optional().describe("New state. On a BLOCKER (task) comment, 'RESOLVED' ticks the task and 'OPEN' un-ticks it. This is NOT the thread-level 'Resolve' button on regular comment threads — that is a separate concept (CommentThread.resolved) and is not exposed by this endpoint."),
+    severity: z.enum(['NORMAL', 'BLOCKER']).optional().describe("New severity. Use 'BLOCKER' to convert a comment into a task, 'NORMAL' to convert it back."),
     output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
   },
   getUser: {

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -129,10 +129,20 @@ server.tool(
 
 server.tool(
   "bitbucket_postPullRequestComment",
-  "Post a comment to a Bitbucket pull request. Use pending: true to create a draft comment that is only visible to you until you call bitbucket_submitPullRequestReview. NOTE: pending only works when filePath is provided (file-level or inline comments). True top-level PR comments (no filePath) are always posted live and cannot be drafted.",
+  "Post a comment to a Bitbucket pull request. Use pending: true to create a draft comment that is only visible to you until you call bitbucket_submitPullRequestReview. NOTE: pending only works when filePath is provided (file-level or inline comments). True top-level PR comments (no filePath) are always posted live and cannot be drafted. Use severity: 'BLOCKER' to post the comment as a task — tasks must be resolved before the PR can be merged.",
   bitbucketToolSchemas.postPullRequestComment,
-  async ({ projectKey, repositorySlug, pullRequestId, text, parentId, filePath, line, lineType, pending, output }) => {
-    const result = await bitbucketService.postPullRequestComment(projectKey, repositorySlug, pullRequestId, text, parentId, filePath, line, lineType, pending, output);
+  async ({ projectKey, repositorySlug, pullRequestId, text, parentId, filePath, line, lineType, pending, severity, output }) => {
+    const result = await bitbucketService.postPullRequestComment(projectKey, repositorySlug, pullRequestId, text, parentId, filePath, line, lineType, pending, severity, output);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_updatePullRequestComment",
+  "Update an existing pull request comment. Use to edit text, change severity, or change state. On a BLOCKER (task) comment, state: 'RESOLVED' ticks the task. NOTE: this is the task-tick, not the thread-level 'Resolve' button on regular comment threads — that is a separate concept (CommentThread.resolved) and is not exposed by this endpoint. Requires the current 'version' from optimistic locking; fetch it via bitbucket_getPR_CommentsAndAction or use the version returned when the comment was created.",
+  bitbucketToolSchemas.updatePullRequestComment,
+  async ({ projectKey, repositorySlug, pullRequestId, commentId, version, text, state, severity, output }) => {
+    const result = await bitbucketService.updatePullRequestComment(projectKey, repositorySlug, pullRequestId, commentId, version, text, state, severity, output);
     return formatToolResponse(result);
   }
 );


### PR DESCRIPTION
# Summary

This change extends the Bitbucket MCP server with first-class support for PR tasks.

The existing `bitbucket_postPullRequestComment` tool gains an optional `severity` parameter. Passing `'BLOCKER'` posts the comment as a task — a comment that must be ticked off before the PR can be merged. Omitting the parameter (or passing `'NORMAL'`) preserves the previous behaviour of posting a regular comment, so existing integrations are unaffected. The parameter mirrors the underlying Bitbucket API's `severity` field directly, following the same enum-style pattern as the existing `lineType` parameter.

A new `bitbucket_updatePullRequestComment` tool wraps `PUT /pull-requests/{id}/comments/{commentId}`. It supports editing comment text, changing severity (promoting a comment to a task or demoting it back), and ticking or un-ticking a task via `state: 'RESOLVED' | 'OPEN'`. As required by the Bitbucket API, callers must supply the comment's current `version` for optimistic locking — this is available from `bitbucket_getPR_CommentsAndAction` or from the response of the original post/update.

One subtlety worth calling out: the `state` field on a task comment is distinct from the thread-level "Resolve" button shown on regular comment threads in the Bitbucket UI. The latter operates on `CommentThread.resolved`, which is a separate concept and is not exposed by the underlying `updateComment2` endpoint. The tool description and JSDoc make this explicit so consumers do not conflate the two.

---

_Disclaimer: this code was written with the assistance of Claude Code._