### PR TITLE
feat(bitbucket): support creating and updating pull requests as drafts

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-token-optimization.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-token-optimization.test.ts
@@ -405,7 +405,7 @@ describe('BitbucketService token optimization paths', () => {
       };
       (PullRequestsService.create as jest.Mock).mockResolvedValue(mockPullRequest);
 
-      const result = await service.createPullRequest('TEST', 'repo', 'Raw create', undefined, 'refs/heads/feature', 'refs/heads/main', undefined, 'full');
+      const result = await service.createPullRequest('TEST', 'repo', 'Raw create', undefined, 'refs/heads/feature', 'refs/heads/main', undefined, undefined, 'full');
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(mockPullRequest);
@@ -420,7 +420,7 @@ describe('BitbucketService token optimization paths', () => {
       };
       (PullRequestsService.update as jest.Mock).mockResolvedValue(mockPullRequest);
 
-      const result = await service.updatePullRequest('TEST', 'repo', '123', 1, 'Raw update', undefined, undefined, 'full');
+      const result = await service.updatePullRequest('TEST', 'repo', '123', 1, 'Raw update', undefined, undefined, undefined, 'full');
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(mockPullRequest);

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -506,6 +506,8 @@ export class BitbucketService {
    * @param fromRefId The source branch (e.g., 'refs/heads/feature-branch')
    * @param toRefId The destination branch (e.g., 'refs/heads/main')
    * @param reviewers Optional array of reviewer usernames
+   * @param draft Optional flag to create the pull request as a draft
+   * @param output Return a compact acknowledgement or the full API response. Defaults to 'ack'.
    * @returns Promise with created pull request data
    */
   async createPullRequest(
@@ -516,6 +518,7 @@ export class BitbucketService {
     fromRefId: string,
     toRefId: string,
     reviewers?: string[],
+    draft?: boolean,
     output: BitbucketMutationOutputMode = 'ack'
   ) {
     projectKey = projectKey.toUpperCase();
@@ -551,6 +554,10 @@ export class BitbucketService {
       }));
     }
 
+    if (draft !== undefined) {
+      pullRequestData.draft = draft;
+    }
+
     const result = await handleApiOperation(
       () => PullRequestsService.create(projectKey, repositorySlug, pullRequestData),
       'Error creating pull request'
@@ -575,6 +582,8 @@ export class BitbucketService {
    * @param title Optional new title for the pull request
    * @param description Optional new description for the pull request
    * @param reviewers Optional array of reviewer usernames to set
+   * @param draft Optional flag to mark the pull request as a draft or ready for review
+   * @param output Return a compact acknowledgement or the full API response. Defaults to 'ack'.
    * @returns Promise with updated pull request data
    */
   async updatePullRequest(
@@ -585,6 +594,7 @@ export class BitbucketService {
     title?: string,
     description?: string,
     reviewers?: string[],
+    draft?: boolean,
     output: BitbucketMutationOutputMode = 'ack'
   ) {
     projectKey = projectKey.toUpperCase();
@@ -607,6 +617,10 @@ export class BitbucketService {
           name: username
         }
       }));
+    }
+
+    if (draft !== undefined) {
+      pullRequestData.draft = draft;
     }
 
     const result = await handleApiOperation(
@@ -853,6 +867,7 @@ export const bitbucketToolSchemas = {
     fromRefId: z.string().describe("The source branch reference ID (e.g., 'refs/heads/feature-branch')"),
     toRefId: z.string().describe("The destination branch reference ID (e.g., 'refs/heads/main')"),
     reviewers: z.array(z.string()).optional().describe("Optional array of reviewer usernames"),
+    draft: z.boolean().optional().describe("If true, the pull request is created as a draft (work-in-progress) and cannot be merged until marked ready."),
     output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
   },
   updatePullRequest: {
@@ -863,6 +878,7 @@ export const bitbucketToolSchemas = {
     title: z.string().optional().describe("The new title for the pull request"),
     description: z.string().optional().describe("The new description for the pull request"),
     reviewers: z.array(z.string()).optional().describe("Optional array of reviewer usernames to set"),
+    draft: z.boolean().optional().describe("If provided, sets the draft (work-in-progress) status of the pull request. Pass true to mark as draft, false to mark as ready for review."),
     output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
   },
   getRequiredReviewers: {

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -162,8 +162,8 @@ server.tool(
   "bitbucket_createPullRequest",
   "Create a new pull request in a Bitbucket repository. IMPORTANT: Before creating a PR, use bitbucket_getRequiredReviewers to fetch required reviewers for the source and target branches to ensure the PR is not created without mandatory reviewers.",
   bitbucketToolSchemas.createPullRequest,
-  async ({ projectKey, repositorySlug, title, description, fromRefId, toRefId, reviewers, output }) => {
-    const result = await bitbucketService.createPullRequest(projectKey, repositorySlug, title, description, fromRefId, toRefId, reviewers, output);
+  async ({ projectKey, repositorySlug, title, description, fromRefId, toRefId, reviewers, draft, output }) => {
+    const result = await bitbucketService.createPullRequest(projectKey, repositorySlug, title, description, fromRefId, toRefId, reviewers, draft, output);
     return formatToolResponse(result);
   }
 );
@@ -172,8 +172,8 @@ server.tool(
   "bitbucket_updatePullRequest",
   "Update the title, description, reviewers, destination branch or draft status of an existing pull request. IMPORTANT: You MUST first call bitbucket_getPullRequest to get the current 'version' number — this is required for optimistic locking and the call will fail without it. The reviewers parameter replaces ALL existing reviewers. If you want to preserve existing reviewers, include those from the current PR details along with any new ones you want to add.",
   bitbucketToolSchemas.updatePullRequest,
-  async ({ projectKey, repositorySlug, pullRequestId, version, title, description, reviewers, output }) => {
-    const result = await bitbucketService.updatePullRequest(projectKey, repositorySlug, pullRequestId, version, title, description, reviewers, output);
+  async ({ projectKey, repositorySlug, pullRequestId, version, title, description, reviewers, draft, output }) => {
+    const result = await bitbucketService.updatePullRequest(projectKey, repositorySlug, pullRequestId, version, title, description, reviewers, draft, output);
     return formatToolResponse(result);
   }
 );


### PR DESCRIPTION
# Summary

  - Add `draft?: boolean` to `bitbucket_createPullRequest` and `bitbucket_updatePullRequest`. The flag is threaded through the Zod tool schemas, the service methods, and into the REST payload (only sent when explicitly set, so existing behavior is preserved when omitted).
  - On update, passing `draft: false` flips a draft PR to ready-for-review; passing `draft: true` marks it as draft.
  - Filled in the missing `@param output` JSDoc on both methods while in the neighborhood.

---

_Disclaimer: this code was written with the assistance of Claude Code._