### PR TITLE
feat(bitbucket): add multiline comment support for pull request comments

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -821,6 +821,8 @@ describe('BitbucketService', () => {
         'Line comment',
         undefined, // parentId
         'src/test.js', // filePath
+        undefined, // startLine
+        undefined, // startLineType
         42, // line
         'ADDED' // lineType
       );
@@ -842,6 +844,124 @@ describe('BitbucketService', () => {
             line: 42,
             lineType: 'ADDED',
             fileType: 'TO'
+          }
+        }
+      );
+    });
+
+    it('should successfully post a multiline comment', async () => {
+      const mockComment = {
+        id: 12349,
+        text: 'Multiline comment',
+        author: { displayName: 'Test User' },
+        anchor: {
+          path: 'src/test.js',
+          diffType: 'EFFECTIVE',
+          line: 15,
+          lineType: 'ADDED',
+          fileType: 'TO',
+          multilineAnchor: true,
+          multilineStartLine: 10,
+          multilineStartLineType: 'ADDED',
+          multilineDestinationRange: { minimum: 10, maximum: 15 }
+        }
+      };
+      (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue(mockComment);
+
+      const result = await bitbucketService.postPullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        'Multiline comment',
+        undefined,      // parentId
+        'src/test.js',  // filePath
+        10,             // startLine
+        undefined,      // startLineType (should default to lineType)
+        15,             // line (end line)
+        'ADDED'         // lineType
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        id: 12349,
+        pending: false,
+        anchor: {
+          path: 'src/test.js',
+          line: 15,
+          lineType: 'ADDED',
+          startLine: 10,
+          startLineType: 'ADDED',
+        }
+      });
+      expect(PullRequestsService.createComment2).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        {
+          text: 'Multiline comment',
+          anchor: {
+            path: 'src/test.js',
+            diffType: 'EFFECTIVE',
+            line: 15,
+            lineType: 'ADDED',
+            fileType: 'TO',
+            multilineAnchor: true,
+            multilineStartLine: 10,
+            multilineStartLineType: 'ADDED',
+            multilineDestinationRange: { minimum: 10, maximum: 15 }
+          }
+        }
+      );
+    });
+
+    it('should post a multiline comment with explicit startLineType', async () => {
+      const mockComment = {
+        id: 12350,
+        text: 'Mixed multiline comment',
+        author: { displayName: 'Test User' },
+        anchor: {
+          path: 'src/test.js',
+          diffType: 'EFFECTIVE',
+          line: 8,
+          lineType: 'ADDED',
+          fileType: 'TO',
+          multilineAnchor: true,
+          multilineStartLine: 5,
+          multilineStartLineType: 'CONTEXT',
+          multilineDestinationRange: { minimum: 5, maximum: 8 }
+        }
+      };
+      (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue(mockComment);
+
+      await bitbucketService.postPullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        'Mixed multiline comment',
+        undefined,      // parentId
+        'src/test.js',  // filePath
+        5,              // startLine
+        'CONTEXT',      // startLineType
+        8,              // line (end line)
+        'ADDED'         // lineType
+      );
+
+      expect(PullRequestsService.createComment2).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        {
+          text: 'Mixed multiline comment',
+          anchor: {
+            path: 'src/test.js',
+            diffType: 'EFFECTIVE',
+            line: 8,
+            lineType: 'ADDED',
+            fileType: 'TO',
+            multilineAnchor: true,
+            multilineStartLine: 5,
+            multilineStartLineType: 'CONTEXT',
+            multilineDestinationRange: { minimum: 5, maximum: 8 }
           }
         }
       );
@@ -1894,6 +2014,8 @@ describe('BitbucketService', () => {
         'Draft comment',
         undefined, // parentId
         undefined, // filePath
+        undefined, // startLine
+        undefined, // startLineType
         undefined, // line
         undefined, // lineType
         true       // pending
@@ -1938,6 +2060,8 @@ describe('BitbucketService', () => {
         'Pending file comment',
         undefined,      // parentId
         'src/index.ts', // filePath
+        undefined,      // startLine
+        undefined,      // startLineType
         10,             // line
         'ADDED',        // lineType
         true            // pending

--- a/packages/bitbucket/src/__tests__/bitbucket-token-optimization.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-token-optimization.test.ts
@@ -390,7 +390,7 @@ describe('BitbucketService token optimization paths', () => {
       };
       (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue(mockComment);
 
-      const result = await service.postPullRequestComment('TEST', 'repo', '123', 'Raw comment', undefined, undefined, undefined, undefined, undefined, 'full');
+      const result = await service.postPullRequestComment('TEST', 'repo', '123', 'Raw comment', undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'full');
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(mockComment);

--- a/packages/bitbucket/src/bitbucket-response-mapper.ts
+++ b/packages/bitbucket/src/bitbucket-response-mapper.ts
@@ -113,6 +113,12 @@ export function shapePullRequestCommentAck(comment: any): Record<string, any> {
             path: comment.anchor.path,
             ...(comment.anchor.line !== undefined ? { line: comment.anchor.line } : {}),
             ...(typeof comment.anchor.lineType === 'string' ? { lineType: comment.anchor.lineType } : {}),
+            ...(comment.anchor.multilineAnchor
+              ? {
+                  startLine: comment.anchor.multilineStartLine,
+                  startLineType: comment.anchor.multilineStartLineType,
+                }
+              : {}),
           },
         }
       : {}),

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -301,8 +301,10 @@ export class BitbucketService {
    * @param text The comment text
    * @param parentId Optional parent comment ID for replies
    * @param filePath Optional file path for file-specific comments
-   * @param line Optional line number for line-specific comments
-   * @param lineType Optional line type ('ADDED', 'REMOVED', 'CONTEXT') for line comments
+   * @param line Optional end line number for line/multiline comments
+   * @param lineType Optional line type ('ADDED', 'REMOVED', 'CONTEXT') for the end line
+   * @param startLine Optional start line for multiline comments; when provided together with line, creates a range comment
+   * @param startLineType Optional line type for the start line; defaults to lineType if omitted
    * @param pending Optional flag to create a pending (draft) comment, not visible to others until a review is submitted.
    *   Only works when filePath is provided (file-level or inline comments).
    *   Top-level PR comments (no filePath) are always posted live regardless of this flag.
@@ -315,6 +317,8 @@ export class BitbucketService {
     text: string,
     parentId?: number,
     filePath?: string,
+    startLine?: number,
+    startLineType?: 'ADDED' | 'REMOVED' | 'CONTEXT',
     line?: number,
     lineType?: 'ADDED' | 'REMOVED' | 'CONTEXT',
     pending?: boolean,
@@ -349,6 +353,14 @@ export class BitbucketService {
         comment.anchor.line = line;
         comment.anchor.lineType = lineType;
         comment.anchor.fileType = 'TO'; // Default to destination file
+
+        if (startLine !== undefined) {
+          const resolvedStartLineType = startLineType ?? lineType;
+          comment.anchor.multilineAnchor = true;
+          comment.anchor.multilineStartLine = startLine;
+          comment.anchor.multilineStartLineType = resolvedStartLineType;
+          comment.anchor.multilineDestinationRange = { minimum: startLine, maximum: line };
+        }
       }
     }
 
@@ -816,8 +828,10 @@ export const bitbucketToolSchemas = {
     text: z.string().describe("The comment text"),
     parentId: z.number().optional().describe("Parent comment ID for replies"),
     filePath: z.string().optional().describe("File path for file-specific comments"),
-    line: z.number().optional().describe("Line number for line-specific comments"),
-    lineType: z.enum(['ADDED', 'REMOVED', 'CONTEXT']).optional().describe("Line type for line comments"),
+    startLine: z.number().optional().describe("Start line of a multiline comment range. When provided together with 'line' (end line), creates a multiline comment spanning from startLine to line."),
+    startLineType: z.enum(['ADDED', 'REMOVED', 'CONTEXT']).optional().describe("Line type for the start line of a multiline comment. Defaults to the same value as lineType if omitted."),
+    line: z.number().optional().describe("Line number for single-line comments, or end line for multiline comments"),
+    lineType: z.enum(['ADDED', 'REMOVED', 'CONTEXT']).optional().describe("Line type for the end line (or the only line for single-line comments)"),
     pending: z.boolean().optional().describe("If true, creates a pending (draft) comment not visible to others until the review is submitted via bitbucket_submitPullRequestReview. Only works when filePath is provided — top-level PR comments (no filePath) are always posted live."),
     output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
   },

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -131,8 +131,8 @@ server.tool(
   "bitbucket_postPullRequestComment",
   "Post a comment to a Bitbucket pull request. Use pending: true to create a draft comment that is only visible to you until you call bitbucket_submitPullRequestReview. NOTE: pending only works when filePath is provided (file-level or inline comments). True top-level PR comments (no filePath) are always posted live and cannot be drafted.",
   bitbucketToolSchemas.postPullRequestComment,
-  async ({ projectKey, repositorySlug, pullRequestId, text, parentId, filePath, line, lineType, pending, output }) => {
-    const result = await bitbucketService.postPullRequestComment(projectKey, repositorySlug, pullRequestId, text, parentId, filePath, line, lineType, pending, output);
+  async ({ projectKey, repositorySlug, pullRequestId, text, parentId, filePath, startLine, startLineType, line, lineType, pending, output }) => {
+    const result = await bitbucketService.postPullRequestComment(projectKey, repositorySlug, pullRequestId, text, parentId, filePath, startLine, startLineType, line, lineType, pending, output);
     return formatToolResponse(result);
   }
 );


### PR DESCRIPTION
## Summary

- Add `startLine` and `startLineType` optional parameters to `bitbucket_postPullRequestComment` tool
- When `startLine` is provided together with `line`, the comment is anchored as a multiline range (`multilineAnchor: true`) spanning from `startLine` to `line`
- `startLineType` defaults to the same value as `lineType` if omitted
- Response ACK now includes `startLine` / `startLineType` in the `anchor` field for multiline comments
- All existing single-line and file-level comment behaviour is unchanged (fully backward-compatible)

## Test plan

- [ ] Existing tests pass: `npm run test --workspace=@atlassian-dc-mcp/bitbucket` (128 tests, 6 suites)
- [ ] New test: multiline comment sets correct anchor fields (`multilineAnchor`, `multilineStartLine`, `multilineStartLineType`, `multilineDestinationRange`)
- [ ] New test: explicit `startLineType` overrides the default fallback to `lineType`
- [ ] Manually verify against a Bitbucket DC instance: post a comment with `startLine=10, line=15, lineType='ADDED'` and confirm the comment highlights the range in the diff view