### PR TITLE
feat(jira): add jira_getIssueDevelopmentInfo tool for issue Development panel

### DIFF
--- a/packages/jira/src/__tests__/jira-service.test.ts
+++ b/packages/jira/src/__tests__/jira-service.test.ts
@@ -4,6 +4,11 @@ import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { JiraService } from '../jira-service.js';
 import { IssueService, OpenAPI, SearchService } from '../jira-client/index.js';
+import { request as __request } from '../jira-client/core/request.js';
+
+jest.mock('../jira-client/core/request.js', () => ({
+  request: jest.fn(),
+}));
 
 jest.mock('../jira-client/index.js', () => ({
   IssueService: {
@@ -182,6 +187,58 @@ describe('JiraService', () => {
       await jiraService.getIssueComments(mockIssueKey, 'renderedBody', 10, 20);
 
       expect(IssueService.getComments).toHaveBeenCalledWith(mockIssueKey, 'renderedBody', '10', undefined, '20');
+    });
+  });
+
+  describe('getIssueDevelopmentInfo', () => {
+    it('resolves the numeric issue id then requests pull requests by default', async () => {
+      const mockDevInfo = { detail: [{ pullRequests: [] }] };
+      (IssueService.getIssue as jest.Mock).mockResolvedValue({ id: '1314681', key: mockIssueKey });
+      (__request as jest.Mock).mockResolvedValue(mockDevInfo);
+
+      const result = await jiraService.getIssueDevelopmentInfo(mockIssueKey);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockDevInfo);
+      expect(IssueService.getIssue).toHaveBeenCalledWith(mockIssueKey, undefined, ['id']);
+      expect(__request).toHaveBeenCalledWith(OpenAPI, {
+        method: 'GET',
+        url: '/dev-status/1.0/issue/detail',
+        query: { issueId: '1314681', applicationType: 'stash', dataType: 'pullrequest' },
+      });
+    });
+
+    it('honors explicit dataType and applicationType', async () => {
+      (IssueService.getIssue as jest.Mock).mockResolvedValue({ id: '42' });
+      (__request as jest.Mock).mockResolvedValue({});
+
+      await jiraService.getIssueDevelopmentInfo(mockIssueKey, 'repository', 'github');
+
+      expect(__request).toHaveBeenCalledWith(OpenAPI, {
+        method: 'GET',
+        url: '/dev-status/1.0/issue/detail',
+        query: { issueId: '42', applicationType: 'github', dataType: 'repository' },
+      });
+    });
+
+    it('fails without calling dev-status when the numeric id is missing', async () => {
+      (IssueService.getIssue as jest.Mock).mockResolvedValue({ key: mockIssueKey });
+
+      const result = await jiraService.getIssueDevelopmentInfo(mockIssueKey);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(`Could not resolve numeric id for issue ${mockIssueKey}`);
+      expect(__request).not.toHaveBeenCalled();
+    });
+
+    it('surfaces dev-status request errors', async () => {
+      (IssueService.getIssue as jest.Mock).mockResolvedValue({ id: '1314681' });
+      (__request as jest.Mock).mockRejectedValue(new Error('View Development Tools permission required'));
+
+      const result = await jiraService.getIssueDevelopmentInfo(mockIssueKey);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('View Development Tools permission required');
     });
   });
 

--- a/packages/jira/src/index.ts
+++ b/packages/jira/src/index.ts
@@ -98,6 +98,16 @@ server.tool(
 );
 
 server.tool(
+  "jira_getIssueDevelopmentInfo",
+  `Get linked development information (pull requests, commits, or branches) shown in the Development panel of a JIRA issue in the ${jiraInstanceType}. Defaults to pull requests from Bitbucket.`,
+  jiraToolSchemas.getIssueDevelopmentInfo,
+  async ({ issueKey, dataType, applicationType }) => {
+    const result = await jiraService.getIssueDevelopmentInfo(issueKey, dataType, applicationType);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
   "jira_transitionIssue",
   `Transition a JIRA issue to a new status in the ${jiraInstanceType}. Use jira_getTransitions first to get available transition IDs.`,
   jiraToolSchemas.transitionIssue,

--- a/packages/jira/src/jira-service.ts
+++ b/packages/jira/src/jira-service.ts
@@ -1,11 +1,15 @@
 import { z } from 'zod';
 import { handleApiOperation, resolveOpenApiBase } from '@atlassian-dc-mcp/common';
 import { IssueService, MyselfService, OpenAPI, SearchService } from './jira-client/index.js';
+import { request as __request } from './jira-client/core/request.js';
 import type { StringList } from './jira-client/models/StringList.js';
 import { getDefaultPageSize, getMissingConfig, JIRA_PRODUCT } from './config.js';
 
 const DEFAULT_SEARCH_FIELDS = ['summary', 'description', 'status', 'assignee', 'reporter', 'priority', 'issuetype', 'labels', 'updated'];
 const DEFAULT_ISSUE_FIELDS = [...DEFAULT_SEARCH_FIELDS, 'parent', 'subtasks'];
+
+type DevelopmentDataType = 'pullrequest' | 'repository' | 'branch';
+type DevelopmentApplicationType = 'stash' | 'bitbucket' | 'github' | 'githube';
 
 function toIssueFieldSelection(fields: string[]): Array<StringList> {
   // The generated client types this query param as StringList[], but the API expects repeated string field names.
@@ -129,6 +133,30 @@ export class JiraService {
     );
   }
 
+  async getIssueDevelopmentInfo(
+    issueKey: string,
+    dataType: DevelopmentDataType = 'pullrequest',
+    applicationType: DevelopmentApplicationType = 'stash',
+  ) {
+    return handleApiOperation(async () => {
+      const issueId = await this.resolveIssueId(issueKey);
+      return __request(OpenAPI, {
+        method: 'GET',
+        url: '/dev-status/1.0/issue/detail',
+        query: { issueId, applicationType, dataType },
+      });
+    }, 'Error getting issue development info');
+  }
+
+  private async resolveIssueId(issueKey: string): Promise<string> {
+    // The dev-status API is keyed by the numeric issue id, not the issue key.
+    const issue = await IssueService.getIssue(issueKey, undefined, toIssueFieldSelection(['id']));
+    if (!issue?.id) {
+      throw new Error(`Could not resolve numeric id for issue ${issueKey}`);
+    }
+    return issue.id;
+  }
+
   async transitionIssue(params: {
     issueKey: string;
     transitionId: string;
@@ -193,6 +221,11 @@ export const jiraToolSchemas = {
   },
   getTransitions: {
     issueKey: z.string().describe("JIRA issue key (e.g., PROJ-123)")
+  },
+  getIssueDevelopmentInfo: {
+    issueKey: z.string().describe("JIRA issue key (e.g., PROJ-123)"),
+    dataType: z.enum(['pullrequest', 'repository', 'branch']).optional().describe("Development data to fetch: 'pullrequest' (default), 'repository' (commits), or 'branch'"),
+    applicationType: z.enum(['stash', 'bitbucket', 'github', 'githube']).optional().describe("Linked SCM type: 'stash' (Bitbucket Server/Data Center, default), 'bitbucket' (Cloud), 'github', or 'githube' (GitHub Enterprise)")
   },
   transitionIssue: {
     issueKey: z.string().describe("JIRA issue key (e.g., PROJ-123)"),


### PR DESCRIPTION
## Summary

Adds a new Jira tool, `jira_getIssueDevelopmentInfo`, that returns the data shown in a Jira issue's **Development** panel — linked pull requests, commits, and branches.

This information is not part of the standard issue REST schema (it is not in `issuelinks` or remote links), so it cannot be retrieved with the existing `jira_getIssue` tool. It is served by Jira Data Center's dev-status API, which is the same endpoint the issue-view UI calls to render the panel.

## How it works

- `GET {base}/dev-status/1.0/issue/detail?issueId={id}&applicationType={type}&dataType={type}`
- The dev-status API is keyed by the **numeric** issue id, so the tool first resolves the issue key to its id via `IssueService.getIssue` (`resolveIssueId`).
- Parameters:
  - `dataType`: `pullrequest` (default), `repository` (commits), or `branch`
  - `applicationType`: `stash` (Bitbucket Server/DC, default), `bitbucket` (Cloud), `github`, or `githube` (GitHub Enterprise)
- The call reuses the generated `request(OpenAPI, …)` helper, so Bearer auth, the request timeout, and error mapping are handled exactly like the other services. `OpenAPI.BASE` already resolves to `…/rest`, so the dev-status path is a sibling of `/api/2`.

## Notes

- The dev-status endpoint (`/rest/dev-status/1.0/…`) is internal/undocumented but is stable and is what the Jira UI uses. It requires the calling user to have the **View Development Tools** permission and an application link to the SCM (e.g. Bitbucket).
- Verified live against a Jira Data Center instance: the tool returns the same pull-request rows (id, title, target branch, status, author, reviewers, URL) shown in the Development panel.

## Tests

Adds `getIssueDevelopmentInfo` unit tests in `jira-service.test.ts` covering the default PR fetch, explicit `dataType`/`applicationType`, the missing-numeric-id short-circuit, and dev-status error propagation. The new `request` mock targets `jira-client/core/request.js` (not re-exported from `index.js`). `npm run build` and the new tests pass.
