### PR TITLE
Fix multiline comment/suggestion anchor for Bitbucket Server

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -861,10 +861,8 @@ describe('BitbucketService', () => {
           line: 15,
           lineType: 'ADDED',
           fileType: 'TO',
-          multilineAnchor: true,
-          multilineStartLine: 10,
-          multilineStartLineType: 'ADDED',
-          multilineDestinationRange: { minimum: 10, maximum: 15 }
+          multilineMarker: { startLine: 10, startLineType: 'ADDED' },
+          multilineSpan: { dstSpanStart: 10, dstSpanEnd: 15 }
         }
       };
       (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue(mockComment);
@@ -906,10 +904,8 @@ describe('BitbucketService', () => {
             line: 15,
             lineType: 'ADDED',
             fileType: 'TO',
-            multilineAnchor: true,
-            multilineStartLine: 10,
-            multilineStartLineType: 'ADDED',
-            multilineDestinationRange: { minimum: 10, maximum: 15 }
+            multilineMarker: { startLine: 10, startLineType: 'ADDED' },
+            multilineSpan: { dstSpanStart: 10, dstSpanEnd: 15 }
           }
         }
       );
@@ -926,10 +922,8 @@ describe('BitbucketService', () => {
           line: 8,
           lineType: 'ADDED',
           fileType: 'TO',
-          multilineAnchor: true,
-          multilineStartLine: 5,
-          multilineStartLineType: 'CONTEXT',
-          multilineDestinationRange: { minimum: 5, maximum: 8 }
+          multilineMarker: { startLine: 5, startLineType: 'CONTEXT' },
+          multilineSpan: { dstSpanStart: 5, dstSpanEnd: 8 }
         }
       };
       (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue(mockComment);
@@ -959,13 +953,131 @@ describe('BitbucketService', () => {
             line: 8,
             lineType: 'ADDED',
             fileType: 'TO',
-            multilineAnchor: true,
-            multilineStartLine: 5,
-            multilineStartLineType: 'CONTEXT',
-            multilineDestinationRange: { minimum: 5, maximum: 8 }
+            multilineMarker: { startLine: 5, startLineType: 'CONTEXT' },
+            multilineSpan: { dstSpanStart: 5, dstSpanEnd: 8 }
           }
         }
       );
+    });
+
+    it('should normalize a reversed multiline range (startLine > line)', async () => {
+      (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue({ id: 1, anchor: { path: 'src/test.js' } });
+
+      await bitbucketService.postPullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        'Reversed range',
+        undefined,      // parentId
+        'src/test.js',  // filePath
+        15,             // startLine (greater than line)
+        'ADDED',        // startLineType
+        10,             // line (end line, smaller)
+        'ADDED'         // lineType
+      );
+
+      expect(PullRequestsService.createComment2).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        {
+          text: 'Reversed range',
+          anchor: {
+            path: 'src/test.js',
+            diffType: 'EFFECTIVE',
+            line: 15,
+            lineType: 'ADDED',
+            fileType: 'TO',
+            multilineMarker: { startLine: 10, startLineType: 'ADDED' },
+            multilineSpan: { dstSpanStart: 10, dstSpanEnd: 15 }
+          }
+        }
+      );
+    });
+
+    it('should anchor a REMOVED multiline range to the source file', async () => {
+      (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue({ id: 1, anchor: { path: 'src/test.js' } });
+
+      await bitbucketService.postPullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        'Removed range',
+        undefined,      // parentId
+        'src/test.js',  // filePath
+        2,              // startLine
+        'REMOVED',      // startLineType
+        5,              // line (end line)
+        'REMOVED'       // lineType
+      );
+
+      expect(PullRequestsService.createComment2).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        {
+          text: 'Removed range',
+          anchor: {
+            path: 'src/test.js',
+            diffType: 'EFFECTIVE',
+            line: 5,
+            lineType: 'REMOVED',
+            fileType: 'FROM',
+            multilineMarker: { startLine: 2, startLineType: 'REMOVED' },
+            multilineSpan: { srcSpanStart: 2, srcSpanEnd: 5 }
+          }
+        }
+      );
+    });
+
+    it('should warn when a multi-line suggestion is anchored to a single line', async () => {
+      (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue({
+        id: 99,
+        anchor: { path: 'src/test.js', line: 5, lineType: 'ADDED' }
+      });
+
+      const result = await bitbucketService.postPullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        '```suggestion\nconst a = 1;\nconst b = 2;\n```',
+        undefined,      // parentId
+        'src/test.js',  // filePath
+        undefined,      // startLine (single-line anchor — the bug shape)
+        undefined,      // startLineType
+        5,              // line
+        'ADDED'         // lineType
+      );
+
+      expect(result.success).toBe(true);
+      expect((result.data as any).warning).toMatch(/multi-line ```suggestion/);
+      // single-line anchor: no multiline fields sent
+      const sentAnchor = (PullRequestsService.createComment2 as jest.Mock).mock.calls[0][3].anchor;
+      expect(sentAnchor.multilineMarker).toBeUndefined();
+      expect(sentAnchor.multilineSpan).toBeUndefined();
+    });
+
+    it('should not warn when a multi-line suggestion has a proper multiline range', async () => {
+      (PullRequestsService.createComment2 as jest.Mock).mockResolvedValue({
+        id: 100,
+        anchor: { path: 'src/test.js', line: 5, lineType: 'ADDED', multilineMarker: { startLine: 4, startLineType: 'ADDED' } }
+      });
+
+      const result = await bitbucketService.postPullRequestComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        '```suggestion\nconst a = 1;\nconst b = 2;\n```',
+        undefined,      // parentId
+        'src/test.js',  // filePath
+        4,              // startLine
+        'ADDED',        // startLineType
+        5,              // line
+        'ADDED'         // lineType
+      );
+
+      expect(result.success).toBe(true);
+      expect((result.data as any).warning).toBeUndefined();
     });
 
     it('should handle API errors gracefully', async () => {

--- a/packages/bitbucket/src/bitbucket-response-mapper.ts
+++ b/packages/bitbucket/src/bitbucket-response-mapper.ts
@@ -113,10 +113,10 @@ export function shapePullRequestCommentAck(comment: any): Record<string, any> {
             path: comment.anchor.path,
             ...(comment.anchor.line !== undefined ? { line: comment.anchor.line } : {}),
             ...(typeof comment.anchor.lineType === 'string' ? { lineType: comment.anchor.lineType } : {}),
-            ...(comment.anchor.multilineAnchor
+            ...(comment.anchor.multilineMarker
               ? {
-                  startLine: comment.anchor.multilineStartLine,
-                  startLineType: comment.anchor.multilineStartLineType,
+                  startLine: comment.anchor.multilineMarker.startLine,
+                  startLineType: comment.anchor.multilineMarker.startLineType,
                 }
               : {}),
           },

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -23,6 +23,84 @@ function resolveToken(token: string | (() => string | undefined), missingTokenMe
   };
 }
 
+type DiffLineType = 'ADDED' | 'REMOVED' | 'CONTEXT';
+
+/**
+ * Build a Bitbucket DC inline comment anchor.
+ *
+ * For a multiline range, Bitbucket DC (>= 9.3.0) requires `multilineMarker` + `multilineSpan`.
+ * The legacy `multilineStartLine`/`multilineStartLineType`/`multilineAnchor`/`multilineDestinationRange`
+ * fields are silently ignored by the server, which then stores a single-line anchor — so a multiline
+ * `​```suggestion` only replaces its first line on Apply. Field names verified against BB DC 9.3.2.
+ */
+function buildCommentAnchor(params: {
+  filePath: string;
+  line?: number;
+  lineType?: DiffLineType;
+  startLine?: number;
+  startLineType?: DiffLineType;
+}): Record<string, any> {
+  const { filePath, line, lineType } = params;
+  const anchor: Record<string, any> = { path: filePath, diffType: 'EFFECTIVE' };
+  if (line === undefined || !lineType) {
+    return anchor;
+  }
+
+  if (params.startLine === undefined) {
+    anchor.line = line;
+    anchor.lineType = lineType;
+    anchor.fileType = lineType === 'REMOVED' ? 'FROM' : 'TO';
+    return anchor;
+  }
+
+  // Normalize so the marker sits on the lower line and `line` on the upper line.
+  let startLine = params.startLine;
+  let startLineType: DiffLineType = params.startLineType ?? lineType;
+  let endLine = line;
+  let endLineType: DiffLineType = lineType;
+  if (startLine > endLine) {
+    [startLine, endLine] = [endLine, startLine];
+    [startLineType, endLineType] = [endLineType, startLineType];
+  }
+
+  const fileType = endLineType === 'REMOVED' ? 'FROM' : 'TO';
+  anchor.line = endLine;
+  anchor.lineType = endLineType;
+  anchor.fileType = fileType;
+  anchor.multilineMarker = { startLine, startLineType };
+  anchor.multilineSpan =
+    fileType === 'FROM'
+      ? { srcSpanStart: startLine, srcSpanEnd: endLine }
+      : { dstSpanStart: startLine, dstSpanEnd: endLine };
+  return anchor;
+}
+
+const SUGGESTION_BLOCK_RE = /```suggestion\b[^\n]*\n([\s\S]*?)```/;
+
+/**
+ * Warn when a multi-line `​```suggestion` block is anchored to a single line: Bitbucket only replaces
+ * the anchored line on Apply, leaving the rest (duplicated code). Returns undefined when there is no
+ * concern. Heuristic — a 1-line anchor with a multi-line suggestion is the common failure shape.
+ */
+function multilineSuggestionWarning(text: string, startLine?: number): string | undefined {
+  if (startLine !== undefined) {
+    return undefined;
+  }
+  const match = SUGGESTION_BLOCK_RE.exec(text);
+  if (!match) {
+    return undefined;
+  }
+  const suggestionLineCount = match[1].replace(/\n$/, '').split('\n').length;
+  if (suggestionLineCount <= 1) {
+    return undefined;
+  }
+  return (
+    'The comment contains a multi-line ```suggestion block but is anchored to a single line. ' +
+    'On Apply, Bitbucket replaces only that one line and leaves the rest. To replace multiple lines, ' +
+    'set startLine (first replaced line) and line (last replaced line) to span the whole range.'
+  );
+}
+
 export class BitbucketService {
   private readonly getPageSize: () => number;
 
@@ -349,26 +427,10 @@ export class BitbucketService {
 
     // Add anchor for file/line comments
     if (filePath) {
-      comment.anchor = {
-        path: filePath,
-        diffType: 'EFFECTIVE'
-      };
-
-      // Add line-specific anchor properties
-      if (line !== undefined && lineType) {
-        comment.anchor.line = line;
-        comment.anchor.lineType = lineType;
-        comment.anchor.fileType = 'TO'; // Default to destination file
-
-        if (startLine !== undefined) {
-          const resolvedStartLineType = startLineType ?? lineType;
-          comment.anchor.multilineAnchor = true;
-          comment.anchor.multilineStartLine = startLine;
-          comment.anchor.multilineStartLineType = resolvedStartLineType;
-          comment.anchor.multilineDestinationRange = { minimum: startLine, maximum: line };
-        }
-      }
+      comment.anchor = buildCommentAnchor({ filePath, line, lineType, startLine, startLineType });
     }
+
+    const suggestionWarning = filePath ? multilineSuggestionWarning(text, startLine) : undefined;
 
     const result = await handleApiOperation(
       () => PullRequestsService.createComment2(
@@ -383,8 +445,15 @@ export class BitbucketService {
     if (result.success && result.data && output !== 'full') {
       return {
         ...result,
-        data: shapePullRequestCommentAck(result.data),
+        data: {
+          ...shapePullRequestCommentAck(result.data),
+          ...(suggestionWarning ? { warning: suggestionWarning } : {}),
+        },
       };
+    }
+
+    if (result.success && suggestionWarning) {
+      return { ...result, warning: suggestionWarning };
     }
 
     return result;
@@ -911,10 +980,10 @@ export const bitbucketToolSchemas = {
     text: z.string().describe("The comment text"),
     parentId: z.number().optional().describe("Parent comment ID for replies"),
     filePath: z.string().optional().describe("File path for file-specific comments"),
-    startLine: z.number().optional().describe("Start line of a multiline comment range. When provided together with 'line' (end line), creates a multiline comment spanning from startLine to line."),
-    startLineType: z.enum(['ADDED', 'REMOVED', 'CONTEXT']).optional().describe("Line type for the start line of a multiline comment. Defaults to the same value as lineType if omitted."),
-    line: z.number().optional().describe("Line number for single-line comments, or end line for multiline comments"),
-    lineType: z.enum(['ADDED', 'REMOVED', 'CONTEXT']).optional().describe("Line type for the end line (or the only line for single-line comments)"),
+    startLine: z.number().optional().describe("First line of a multiline range. Provide together with 'line' (the last line) to span multiple lines. REQUIRED for a multi-line ```suggestion: the anchored range (startLine..line) is exactly what 'Apply suggestion' replaces — omit it and only the single 'line' is replaced, leaving the rest. Requires Bitbucket DC >= 9.3.0 for multiline suggestions."),
+    startLineType: z.enum(['ADDED', 'REMOVED', 'CONTEXT']).optional().describe("Line type for the start line of a multiline range. Defaults to the same value as lineType if omitted."),
+    line: z.number().optional().describe("Single-line comments: the line. Multiline: the LAST line of the range (use startLine for the first). For a ```suggestion this is the last replaced line."),
+    lineType: z.enum(['ADDED', 'REMOVED', 'CONTEXT']).optional().describe("Line type for 'line' (the end line, or the only line for single-line comments). Use 'ADDED'/'CONTEXT' for the new/target file, 'REMOVED' for the original/source file."),
     pending: z.boolean().optional().describe("If true, creates a pending (draft) comment not visible to others until the review is submitted via bitbucket_submitPullRequestReview. Only works when filePath is provided — top-level PR comments (no filePath) are always posted live."),
     severity: z.enum(['NORMAL', 'BLOCKER']).optional().describe("Comment severity. Use 'BLOCKER' to post the comment as a task that must be resolved before the PR can be merged. Defaults to 'NORMAL' (regular comment)."),
     output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")

--- a/packages/bitbucket/src/pr-comment-mapper.ts
+++ b/packages/bitbucket/src/pr-comment-mapper.ts
@@ -24,6 +24,10 @@ interface CommentAnchor {
   path: string;
   diffType: string;
   orphaned: boolean;
+  multilineMarker?: {
+    startLine: number;
+    startLineType: string;
+  };
 }
 
 interface CommentProperties {
@@ -131,6 +135,8 @@ interface SimplifiedAnchor {
   line: number;
   path: string;
   fileType?: string;
+  startLine?: number;
+  startLineType?: string;
 }
 
 interface SimplifiedComment {
@@ -240,7 +246,13 @@ function simplifyAnchor(anchor: CommentAnchor): SimplifiedAnchor {
   return {
     line: anchor.line,
     path: anchor.path,
-    fileType: anchor.fileType
+    fileType: anchor.fileType,
+    ...(anchor.multilineMarker
+      ? {
+          startLine: anchor.multilineMarker.startLine,
+          startLineType: anchor.multilineMarker.startLineType
+        }
+      : {})
   };
 }
 


### PR DESCRIPTION
## Problem

Posting a multi-line code **suggestion** (a ```` ```suggestion ```` block) on a Bitbucket Server / Data Center pull request via `bitbucket_postPullRequestComment` did not work: clicking **Apply suggestion** replaced only the **first** line of the range and left the rest, producing duplicated code.

## Root cause

The anchor for a multiline comment was built with the fields:

```
multilineAnchor: true
multilineStartLine, multilineStartLineType
multilineDestinationRange: { minimum, maximum }
```

Bitbucket DC (multiline suggestions shipped in **9.3.0**, [BSERV-12219](https://jira.atlassian.com/browse/BSERV-12219)) does **not** accept those field names — it **silently ignores** them and stores a **single-line** anchor. So the suggestion was only ever anchored to one line.

I reproduced this against a real **Bitbucket DC 9.3.2** instance. The format the server actually expects (and the one its own UI sends) is:

```jsonc
"anchor": {
  "path": "app.js",
  "diffType": "EFFECTIVE",
  "line": 5,                 // last line of the range
  "lineType": "ADDED",
  "fileType": "TO",          // FROM for REMOVED/source-side ranges
  "multilineMarker": { "startLine": 2, "startLineType": "ADDED" },
  "multilineSpan":   { "dstSpanStart": 2, "dstSpanEnd": 5 }   // src* for FROM
}
```

Verified empirically:

| Payload | Stored anchor |
| --- | --- |
| old (`multilineStartLine` + `multilineDestinationRange`) | **single-line** (fields ignored) → bug |
| new (`multilineMarker` + `multilineSpan`) | proper multiline anchor, identical to the UI |

## Fix

- `buildCommentAnchor` now emits `multilineMarker` + `multilineSpan`.
- `fileType` is derived from the line type: `REMOVED` → `FROM` + `srcSpan*` (source side), otherwise `TO` + `dstSpan*` (destination side). Previously `fileType` was hard-coded to `TO`.
- Reversed ranges (`startLine > line`) are normalized.
- A warning is returned when a multi-line ```` ```suggestion ```` is anchored to a single line (the failure shape), so callers notice the range is missing.
- Response/comment mappers read `multilineMarker`; the tool schema documents the multiline-suggestion contract and the DC ≥ 9.3.0 requirement.

## Verification

- `npm run test --workspace=@atlassian-dc-mcp/bitbucket` — **139/139 pass**; build clean.
- End-to-end on Bitbucket DC 9.3.2: created a multiline suggestion with the new format and clicked **Apply** — **all** lines in the range were replaced, no duplication.