### PR TITLE
feat(bitbucket): add PR merge lifecycle tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -23,7 +23,11 @@ jest.mock('../bitbucket-client/index.js', () => ({
     updateStatus: jest.fn(),
     getPage: jest.fn(),
     getReviewers: jest.fn(),
-    get3: jest.fn()
+    get3: jest.fn(),
+    canMerge: jest.fn(),
+    merge: jest.fn(),
+    decline: jest.fn(),
+    reopen: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -1634,6 +1638,256 @@ describe('BitbucketService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Version conflict - PR has been modified');
+    });
+  });
+
+  describe('canMergePullRequest', () => {
+    it('should successfully check mergeability', async () => {
+      const mockMergeability = { canMerge: true, conflicted: false, vetoes: [] };
+      (PullRequestsService.canMerge as jest.Mock).mockResolvedValue(mockMergeability);
+
+      const result = await bitbucketService.canMergePullRequest(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockMergeability);
+      expect(PullRequestsService.canMerge).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      const mockError = new Error('API Error');
+      (PullRequestsService.canMerge as jest.Mock).mockRejectedValue(mockError);
+
+      const result = await bitbucketService.canMergePullRequest(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('mergePullRequest', () => {
+    it('should successfully merge a PR with minimal parameters', async () => {
+      const mockMergedPR = {
+        id: 1,
+        version: 2,
+        title: 'Test PR',
+        state: 'MERGED',
+        fromRef: { id: 'refs/heads/feature-branch' },
+        toRef: { id: 'refs/heads/main' }
+      };
+      (PullRequestsService.merge as jest.Mock).mockResolvedValue(mockMergedPR);
+
+      const result = await bitbucketService.mergePullRequest(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        1
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        id: 1,
+        version: 2,
+        title: 'Test PR',
+        state: 'MERGED',
+        fromRefId: 'refs/heads/feature-branch',
+        toRefId: 'refs/heads/main',
+        reviewerCount: 0,
+      });
+      expect(PullRequestsService.merge).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        '1',
+        {}
+      );
+    });
+
+    it('should pass message and strategyId in the request body', async () => {
+      const mockMergedPR = { id: 1, version: 2, state: 'MERGED' };
+      (PullRequestsService.merge as jest.Mock).mockResolvedValue(mockMergedPR);
+
+      await bitbucketService.mergePullRequest(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        1,
+        'Custom merge message',
+        'squash'
+      );
+
+      expect(PullRequestsService.merge).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        '1',
+        { message: 'Custom merge message', strategyId: 'squash' }
+      );
+    });
+
+    it('should return the full response when output is full', async () => {
+      const mockMergedPR = { id: 1, version: 2, state: 'MERGED' };
+      (PullRequestsService.merge as jest.Mock).mockResolvedValue(mockMergedPR);
+
+      const result = await bitbucketService.mergePullRequest(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        1,
+        undefined,
+        undefined,
+        'full'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockMergedPR);
+    });
+
+    it('should handle merge veto errors gracefully', async () => {
+      const mockError = new Error('The pull request has unresolved tasks');
+      (PullRequestsService.merge as jest.Mock).mockRejectedValue(mockError);
+
+      const result = await bitbucketService.mergePullRequest(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        1
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('The pull request has unresolved tasks');
+    });
+  });
+
+  describe('declinePullRequest', () => {
+    it('should successfully decline a PR', async () => {
+      const mockDeclinedPR = {
+        id: 1,
+        version: 2,
+        title: 'Test PR',
+        state: 'DECLINED'
+      };
+      (PullRequestsService.decline as jest.Mock).mockResolvedValue(mockDeclinedPR);
+
+      const result = await bitbucketService.declinePullRequest(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        1
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        id: 1,
+        version: 2,
+        title: 'Test PR',
+        state: 'DECLINED',
+        reviewerCount: 0,
+      });
+      expect(PullRequestsService.decline).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        '1',
+        {}
+      );
+    });
+
+    it('should pass an optional comment in the request body', async () => {
+      const mockDeclinedPR = { id: 1, version: 2, state: 'DECLINED' };
+      (PullRequestsService.decline as jest.Mock).mockResolvedValue(mockDeclinedPR);
+
+      await bitbucketService.declinePullRequest(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        1,
+        'Superseded by another PR'
+      );
+
+      expect(PullRequestsService.decline).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        '1',
+        { comment: 'Superseded by another PR' }
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      const mockError = new Error('API Error');
+      (PullRequestsService.decline as jest.Mock).mockRejectedValue(mockError);
+
+      const result = await bitbucketService.declinePullRequest(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        1
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('reopenPullRequest', () => {
+    it('should successfully reopen a declined PR', async () => {
+      const mockReopenedPR = {
+        id: 1,
+        version: 3,
+        title: 'Test PR',
+        state: 'OPEN'
+      };
+      (PullRequestsService.reopen as jest.Mock).mockResolvedValue(mockReopenedPR);
+
+      const result = await bitbucketService.reopenPullRequest(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        2
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        id: 1,
+        version: 3,
+        title: 'Test PR',
+        state: 'OPEN',
+        reviewerCount: 0,
+      });
+      expect(PullRequestsService.reopen).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        '2',
+        {}
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      const mockError = new Error('Pull request is not declined');
+      (PullRequestsService.reopen as jest.Mock).mockRejectedValue(mockError);
+
+      const result = await bitbucketService.reopenPullRequest(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        2
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Pull request is not declined');
     });
   });
 

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -720,6 +720,132 @@ export class BitbucketService {
   }
 
   /**
+   * Check whether a pull request can be merged
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param pullRequestId The pull request ID
+   * @returns Promise with mergeability data (canMerge, conflicted, vetoes)
+   */
+  async canMergePullRequest(
+    projectKey: string,
+    repositorySlug: string,
+    pullRequestId: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => PullRequestsService.canMerge(projectKey, pullRequestId, repositorySlug),
+      'Error checking pull request mergeability'
+    );
+  }
+
+  /**
+   * Merge a pull request
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param pullRequestId The pull request ID
+   * @param version The current version of the pull request (required for optimistic locking)
+   * @param message Optional custom merge commit message
+   * @param strategyId Optional merge strategy id (e.g. 'no-ff', 'ff', 'ff-only', 'rebase-no-ff', 'squash')
+   * @param output Return a compact acknowledgement or the full API response. Defaults to 'ack'.
+   * @returns Promise with merged pull request data
+   */
+  async mergePullRequest(
+    projectKey: string,
+    repositorySlug: string,
+    pullRequestId: string,
+    version: number,
+    message?: string,
+    strategyId?: string,
+    output: BitbucketMutationOutputMode = 'ack'
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody: any = {
+      ...(message ? { message } : {}),
+      ...(strategyId ? { strategyId } : {}),
+    };
+
+    const result = await handleApiOperation(
+      () => PullRequestsService.merge(projectKey, pullRequestId, repositorySlug, String(version), requestBody),
+      'Error merging pull request'
+    );
+
+    if (result.success && result.data && output !== 'full') {
+      return { ...result, data: shapePullRequestAck(result.data) };
+    }
+
+    return result;
+  }
+
+  /**
+   * Decline a pull request
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param pullRequestId The pull request ID
+   * @param version The current version of the pull request (required for optimistic locking)
+   * @param comment Optional comment explaining why the pull request was declined
+   * @param output Return a compact acknowledgement or the full API response. Defaults to 'ack'.
+   * @returns Promise with declined pull request data
+   */
+  async declinePullRequest(
+    projectKey: string,
+    repositorySlug: string,
+    pullRequestId: string,
+    version: number,
+    comment?: string,
+    output: BitbucketMutationOutputMode = 'ack'
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody: any = {
+      ...(comment ? { comment } : {}),
+    };
+
+    const result = await handleApiOperation(
+      () => PullRequestsService.decline(projectKey, pullRequestId, repositorySlug, String(version), requestBody),
+      'Error declining pull request'
+    );
+
+    if (result.success && result.data && output !== 'full') {
+      return { ...result, data: shapePullRequestAck(result.data) };
+    }
+
+    return result;
+  }
+
+  /**
+   * Reopen a declined pull request
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param pullRequestId The pull request ID
+   * @param version The current version of the pull request (required for optimistic locking)
+   * @param output Return a compact acknowledgement or the full API response. Defaults to 'ack'.
+   * @returns Promise with reopened pull request data
+   */
+  async reopenPullRequest(
+    projectKey: string,
+    repositorySlug: string,
+    pullRequestId: string,
+    version: number,
+    output: BitbucketMutationOutputMode = 'ack'
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+
+    const result = await handleApiOperation(
+      () => PullRequestsService.reopen(projectKey, pullRequestId, repositorySlug, String(version), {}),
+      'Error reopening pull request'
+    );
+
+    if (result.success && result.data && output !== 'full') {
+      return { ...result, data: shapePullRequestAck(result.data) };
+    }
+
+    return result;
+  }
+
+  /**
    * Get required reviewers for PR creation
    * Returns a set of users who are required reviewers for pull requests created from the given source repository
    * and ref to the given target ref in this repository.
@@ -974,6 +1100,35 @@ export const bitbucketToolSchemas = {
     description: z.string().optional().describe("The new description for the pull request"),
     draft: z.boolean().optional().describe("If provided, sets the draft (work-in-progress) status of the pull request. Pass true to mark as draft, false to mark as ready for review."),
     reviewers: z.array(z.string()).optional().describe("Optional array of reviewer usernames to set (use the 'name' field from Bitbucket user objects, not 'slug')"),
+    output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
+  },
+  canMergePullRequest: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID")
+  },
+  mergePullRequest: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID"),
+    version: z.number().describe("The current version of the pull request (required for optimistic locking). Obtain it via bitbucket_getPullRequest. Use bitbucket_canMergePullRequest first to confirm there are no merge vetoes."),
+    message: z.string().optional().describe("Optional custom merge commit message"),
+    strategyId: z.string().optional().describe("Optional merge strategy id, e.g. 'no-ff', 'ff', 'ff-only', 'rebase-no-ff', or 'squash'. Must be enabled on the repository. Defaults to the repository's configured strategy."),
+    output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
+  },
+  declinePullRequest: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID"),
+    version: z.number().describe("The current version of the pull request (required for optimistic locking). Obtain it via bitbucket_getPullRequest."),
+    comment: z.string().optional().describe("Optional comment explaining why the pull request is being declined"),
+    output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
+  },
+  reopenPullRequest: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID"),
+    version: z.number().describe("The current version of the declined pull request (required for optimistic locking). Obtain it via bitbucket_getPullRequest."),
     output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
   },
   getRequiredReviewers: {

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -159,6 +159,46 @@ server.tool(
 
 
 server.tool(
+  "bitbucket_canMergePullRequest",
+  "Check whether a pull request can be merged. Returns canMerge, conflicted, and a list of vetoes (e.g. unresolved tasks, insufficient approvals, merge conflicts). Use this as a read-only guard before calling bitbucket_mergePullRequest.",
+  bitbucketToolSchemas.canMergePullRequest,
+  async ({ projectKey, repositorySlug, pullRequestId }) => {
+    const result = await bitbucketService.canMergePullRequest(projectKey, repositorySlug, pullRequestId);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_mergePullRequest",
+  "Merge a pull request. IMPORTANT: You MUST first call bitbucket_getPullRequest to get the current 'version' (optimistic locking) — the call fails without it. Recommended: call bitbucket_canMergePullRequest first to ensure there are no merge vetoes. Optionally pass a custom merge message and a strategyId (must be enabled on the repository).",
+  bitbucketToolSchemas.mergePullRequest,
+  async ({ projectKey, repositorySlug, pullRequestId, version, message, strategyId, output }) => {
+    const result = await bitbucketService.mergePullRequest(projectKey, repositorySlug, pullRequestId, version, message, strategyId, output);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_declinePullRequest",
+  "Decline (reject) an open pull request without merging. IMPORTANT: You MUST first call bitbucket_getPullRequest to get the current 'version' (optimistic locking). Optionally pass a comment explaining the decision. A declined PR can later be reopened with bitbucket_reopenPullRequest.",
+  bitbucketToolSchemas.declinePullRequest,
+  async ({ projectKey, repositorySlug, pullRequestId, version, comment, output }) => {
+    const result = await bitbucketService.declinePullRequest(projectKey, repositorySlug, pullRequestId, version, comment, output);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_reopenPullRequest",
+  "Reopen a previously declined pull request. IMPORTANT: You MUST first call bitbucket_getPullRequest to get the current 'version' (optimistic locking). Only works on PRs in the DECLINED state.",
+  bitbucketToolSchemas.reopenPullRequest,
+  async ({ projectKey, repositorySlug, pullRequestId, version, output }) => {
+    const result = await bitbucketService.reopenPullRequest(projectKey, repositorySlug, pullRequestId, version, output);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
   "bitbucket_getPullRequestDiff",
   "Get text diff for a specific file in a Bitbucket pull request. Returns plain text diff format. Note: Before getting diff, use getPullRequestChanges to understand what files were changed in the PR",
   bitbucketToolSchemas.getPullRequestDiff,


### PR DESCRIPTION
## Summary

Adds four new Bitbucket MCP tools covering pull request state transitions — closing the biggest Tier 1 gap (the MCP could create and review PRs but not complete their lifecycle).

| Tool | Endpoint | Notes |
|---|---|---|
| `bitbucket_canMergePullRequest` | `GET .../pull-requests/{id}/merge` | Read-only guard: returns `canMerge`, `conflicted`, `vetoes` |
| `bitbucket_mergePullRequest` | `POST .../pull-requests/{id}/merge` | Optional `message` + `strategyId`; requires `version` |
| `bitbucket_declinePullRequest` | `POST .../pull-requests/{id}/decline` | Optional `comment`; requires `version` |
| `bitbucket_reopenPullRequest` | `POST .../pull-requests/{id}/reopen` | Requires `version` |

All three mutations use optimistic locking (`version` from `bitbucket_getPullRequest`) and reuse the existing `shapePullRequestAck` mapper for compact output. No client regeneration needed — the generated client already exposes `PullRequestsService.canMerge/merge/decline/reopen`.

## Testing

- Unit tests added for all four methods (success, body building, `output: full`, error paths). Full bitbucket suite green (146 tests).
- Verified end-to-end against a live Bitbucket Data Center instance: `decline` (OPEN→DECLINED) → `reopen` (DECLINED→OPEN) → `merge` (OPEN→MERGED), plus `canMerge`, with version/optimistic-locking honored at each step.