### PR TITLE
feat(bitbucket): add branch listing tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { PullRequestsService, RepositoryService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,10 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  RepositoryService: {
+    getBranches: jest.fn(),
+    getDefaultBranch1: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -133,6 +137,112 @@ describe('BitbucketService', () => {
         mockProjectKey,
         mockRepositorySlug,
         mockPullRequestId
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('getBranches', () => {
+    it('should successfully get branches with default parameters', async () => {
+      const mockBranchesData = {
+        values: [
+          { id: 'refs/heads/main', displayId: 'main', isDefault: true },
+          { id: 'refs/heads/feature', displayId: 'feature', isDefault: false }
+        ],
+        size: 2,
+        isLastPage: true
+      };
+      (RepositoryService.getBranches as jest.Mock).mockResolvedValue(mockBranchesData);
+
+      const result = await bitbucketService.getBranches(
+        mockProjectKey,
+        mockRepositorySlug
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockBranchesData);
+      expect(RepositoryService.getBranches).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockRepositorySlug,
+        undefined, // boostMatches
+        undefined, // context
+        undefined, // orderBy
+        undefined, // details
+        undefined, // filterText
+        undefined, // base
+        undefined, // start
+        25
+      );
+    });
+
+    it('should pass filterText, orderBy and pagination through', async () => {
+      const mockBranchesData = { values: [], size: 0, isLastPage: true };
+      (RepositoryService.getBranches as jest.Mock).mockResolvedValue(mockBranchesData);
+
+      await bitbucketService.getBranches(
+        mockProjectKey,
+        mockRepositorySlug,
+        'feat',
+        'MODIFICATION',
+        10,
+        50
+      );
+
+      expect(RepositoryService.getBranches).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockRepositorySlug,
+        undefined,
+        undefined,
+        'MODIFICATION',
+        undefined,
+        'feat',
+        undefined,
+        10,
+        50
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      const mockError = new Error('API Error');
+      (RepositoryService.getBranches as jest.Mock).mockRejectedValue(mockError);
+
+      const result = await bitbucketService.getBranches(
+        mockProjectKey,
+        mockRepositorySlug
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('getDefaultBranch', () => {
+    it('should successfully get the default branch', async () => {
+      const mockBranch = { id: 'refs/heads/main', displayId: 'main', isDefault: true };
+      (RepositoryService.getDefaultBranch1 as jest.Mock).mockResolvedValue(mockBranch);
+
+      const result = await bitbucketService.getDefaultBranch(
+        mockProjectKey,
+        mockRepositorySlug
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockBranch);
+      expect(RepositoryService.getDefaultBranch1).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockRepositorySlug
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      const mockError = new Error('API Error');
+      (RepositoryService.getDefaultBranch1 as jest.Mock).mockRejectedValue(mockError);
+
+      const result = await bitbucketService.getDefaultBranch(
+        mockProjectKey,
+        mockRepositorySlug
       );
 
       expect(result.success).toBe(false);

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -137,6 +137,58 @@ export class BitbucketService {
   }
 
   /**
+   * Get branches for a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param filterText Optional text the branch name must contain
+   * @param orderBy Optional ordering: ALPHABETICAL or MODIFICATION (most recently modified first)
+   * @param start Optional pagination start
+   * @param limit Optional pagination limit (defaults to the package page size)
+   * @returns Promise with branches data
+   */
+  async getBranches(
+    projectKey: string,
+    repositorySlug: string,
+    filterText?: string,
+    orderBy?: 'ALPHABETICAL' | 'MODIFICATION',
+    start?: number,
+    limit?: number
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.getBranches(
+        projectKey,
+        repositorySlug,
+        undefined, // boostMatches
+        undefined, // context
+        orderBy,
+        undefined, // details
+        filterText,
+        undefined, // base
+        start,
+        limit ?? this.getPageSize()
+      ),
+      'Error fetching branches'
+    );
+  }
+
+  /**
+   * Get the default branch of a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @returns Promise with the default branch data
+   */
+  async getDefaultBranch(projectKey: string, repositorySlug: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.getDefaultBranch1(projectKey, repositorySlug),
+      'Error fetching default branch'
+    );
+  }
+
+  /**
    * Get pull requests for a repository
    * @param projectKey The project key
    * @param repositorySlug The repository slug
@@ -872,6 +924,18 @@ export const bitbucketToolSchemas = {
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
   },
   getRepository: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug")
+  },
+  getBranches: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    filterText: z.string().optional().describe("Optional text that the returned branch names must contain (substring match)"),
+    orderBy: z.enum(['ALPHABETICAL', 'MODIFICATION']).optional().describe("Ordering of the results: ALPHABETICAL by branch name, or MODIFICATION (most recently modified first)"),
+    start: z.number().optional().describe("Start number for pagination"),
+    limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  getDefaultBranch: {
     projectKey: z.string().describe("The project key"),
     repositorySlug: z.string().describe("The repository slug")
   },

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -68,6 +68,26 @@ server.tool(
 );
 
 server.tool(
+  "bitbucket_getBranches",
+  "Get branches for a Bitbucket repository. Supports filtering by name substring and ordering (ALPHABETICAL or MODIFICATION). Useful before creating a pull request to discover valid source/target refs.",
+  bitbucketToolSchemas.getBranches,
+  async ({ projectKey, repositorySlug, filterText, orderBy, start, limit }) => {
+    const result = await bitbucketService.getBranches(projectKey, repositorySlug, filterText, orderBy, start, limit);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_getDefaultBranch",
+  "Get the default branch of a Bitbucket repository (e.g. main or master). Useful as the target ref when creating a pull request.",
+  bitbucketToolSchemas.getDefaultBranch,
+  async ({ projectKey, repositorySlug }) => {
+    const result = await bitbucketService.getDefaultBranch(projectKey, repositorySlug);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
   "bitbucket_getCommits",
   "Get commits for a Bitbucket repository",
   bitbucketToolSchemas.getCommits,


### PR DESCRIPTION
## Summary

Adds two read-only Bitbucket MCP tools for discovering repository branches — Tier 1 gap. Previously `bitbucket_createPullRequest` had to be called blind, with no way to enumerate valid source/target refs.

| Tool | Endpoint | Notes |
|---|---|---|
| `bitbucket_getBranches` | `GET .../repos/{slug}/branches` | Optional `filterText` (name substring) + `orderBy` (`ALPHABETICAL`/`MODIFICATION`), paginated |
| `bitbucket_getDefaultBranch` | `GET .../repos/{slug}/branches/default` | Returns the repo default branch (e.g. main/master) |

No client regeneration needed — uses the existing `RepositoryService.getBranches` / `getDefaultBranch1`.

## Testing

- Unit tests added (default params, filter/order/pagination pass-through, error paths). Full bitbucket suite green (140 tests).
- Verified against a live Bitbucket Data Center instance: `getBranches` returned the repo branches with correct `isDefault` flags; `getDefaultBranch` returned `master` (`refs/heads/master`).