### PR TITLE
feat(bitbucket): add repository file content tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { PullRequestsService, RepositoryService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,10 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  RepositoryService: {
+    streamRaw: jest.fn(),
+    getContent1: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -133,6 +137,125 @@ describe('BitbucketService', () => {
         mockProjectKey,
         mockRepositorySlug,
         mockPullRequestId
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('getFileContent', () => {
+    it('should successfully get raw file content', async () => {
+      const mockContent = 'const x = 1;\nconst y = 2;\n';
+      (RepositoryService.streamRaw as jest.Mock).mockResolvedValue(mockContent);
+
+      const result = await bitbucketService.getFileContent(
+        mockProjectKey,
+        mockRepositorySlug,
+        'src/index.ts'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockContent);
+      expect(RepositoryService.streamRaw).toHaveBeenCalledWith(
+        'src/index.ts',
+        mockProjectKey,
+        mockRepositorySlug,
+        undefined
+      );
+    });
+
+    it('should pass the at ref through', async () => {
+      const mockContent = 'file content';
+      (RepositoryService.streamRaw as jest.Mock).mockResolvedValue(mockContent);
+
+      await bitbucketService.getFileContent(
+        mockProjectKey,
+        mockRepositorySlug,
+        'README.md',
+        'refs/heads/main'
+      );
+
+      expect(RepositoryService.streamRaw).toHaveBeenCalledWith(
+        'README.md',
+        mockProjectKey,
+        mockRepositorySlug,
+        'refs/heads/main'
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      const mockError = new Error('The repository does not exist.');
+      (RepositoryService.streamRaw as jest.Mock).mockRejectedValue(mockError);
+
+      const result = await bitbucketService.getFileContent(
+        mockProjectKey,
+        mockRepositorySlug,
+        'missing.txt'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('The repository does not exist.');
+    });
+  });
+
+  describe('browseRepository', () => {
+    it('should browse the repository root by default', async () => {
+      const mockBrowse = { children: { values: [{ path: { toString: 'src' }, type: 'DIRECTORY' }] } };
+      (RepositoryService.getContent1 as jest.Mock).mockResolvedValue(mockBrowse);
+
+      const result = await bitbucketService.browseRepository(
+        mockProjectKey,
+        mockRepositorySlug
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockBrowse);
+      expect(RepositoryService.getContent1).toHaveBeenCalledWith(
+        '',
+        mockProjectKey,
+        mockRepositorySlug,
+        undefined, // noContent
+        undefined, // at
+        undefined, // size
+        undefined, // blame
+        undefined  // type
+      );
+    });
+
+    it('should map path, at, type and blame to the generated client', async () => {
+      const mockBrowse = { type: 'FILE' };
+      (RepositoryService.getContent1 as jest.Mock).mockResolvedValue(mockBrowse);
+
+      await bitbucketService.browseRepository(
+        mockProjectKey,
+        mockRepositorySlug,
+        'src/index.ts',
+        'refs/heads/main',
+        true,
+        true
+      );
+
+      expect(RepositoryService.getContent1).toHaveBeenCalledWith(
+        'src/index.ts',
+        mockProjectKey,
+        mockRepositorySlug,
+        undefined,
+        'refs/heads/main',
+        undefined,
+        'true', // blame
+        'true'  // type
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      const mockError = new Error('API Error');
+      (RepositoryService.getContent1 as jest.Mock).mockRejectedValue(mockError);
+
+      const result = await bitbucketService.browseRepository(
+        mockProjectKey,
+        mockRepositorySlug,
+        'src'
       );
 
       expect(result.success).toBe(false);

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -79,6 +79,63 @@ export class BitbucketService {
   }
 
   /**
+   * Get the raw content of a file at a given revision
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param path The path of the file to retrieve
+   * @param at Optional commit hash or ref (e.g. 'refs/heads/main'); defaults to the default branch
+   * @returns Promise with the raw file content
+   */
+  async getFileContent(
+    projectKey: string,
+    repositorySlug: string,
+    path: string,
+    at?: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.streamRaw(path, projectKey, repositorySlug, at),
+      'Error fetching file content'
+    );
+  }
+
+  /**
+   * Browse a repository file or directory
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param path Optional path to browse; defaults to the repository root (directory listing)
+   * @param at Optional commit hash or ref; defaults to the default branch
+   * @param type If true, return only the node type (FILE, DIRECTORY, SUBMODULE) instead of content
+   * @param blame If true, include blame information
+   * @returns Promise with the browse result (directory children or paginated file lines)
+   */
+  async browseRepository(
+    projectKey: string,
+    repositorySlug: string,
+    path: string = '',
+    at?: string,
+    type?: boolean,
+    blame?: boolean
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.getContent1(
+        path,
+        projectKey,
+        repositorySlug,
+        undefined, // noContent
+        at,
+        undefined, // size
+        blame ? 'true' : undefined,
+        type ? 'true' : undefined
+      ),
+      'Error browsing repository content'
+    );
+  }
+
+  /**
    * Get a list of projects
    * @param name Optional filter by project name
    * @param permission Optional filter by permission
@@ -882,6 +939,20 @@ export const bitbucketToolSchemas = {
     since: z.string().optional().describe("The commit ID (exclusively) to retrieve commits after"),
     until: z.string().optional().describe("The commit ID (inclusively) to retrieve commits before"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  getFileContent: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    path: z.string().describe("The path of the file to retrieve (e.g. 'src/index.ts')"),
+    at: z.string().optional().describe("Optional commit hash or ref to read the file at (e.g. 'refs/heads/main' or a commit id). Defaults to the repository's default branch.")
+  },
+  browseRepository: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    path: z.string().optional().describe("Path to browse. Omit or pass an empty string to list the repository root. A directory path returns its children; a file path returns the file content as paginated lines."),
+    at: z.string().optional().describe("Optional commit hash or ref to browse at. Defaults to the repository's default branch."),
+    type: z.boolean().optional().describe("If true, return only the node type (FILE, DIRECTORY, or SUBMODULE) of the path instead of its content."),
+    blame: z.boolean().optional().describe("If true, include blame information in the response.")
   },
   getPullRequestComments: {
     projectKey: z.string().describe("The project key"),

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -78,6 +78,26 @@ server.tool(
 );
 
 server.tool(
+  "bitbucket_getFileContent",
+  "Get the raw text content of a file in a Bitbucket repository at a given ref or commit. Lets you read source files without cloning. Defaults to the repository's default branch when 'at' is omitted.",
+  bitbucketToolSchemas.getFileContent,
+  async ({ projectKey, repositorySlug, path, at }) => {
+    const result = await bitbucketService.getFileContent(projectKey, repositorySlug, path, at);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_browseRepository",
+  "Browse a repository path in a Bitbucket repository. Omit 'path' (or pass empty) to list the root directory; a directory path lists its children; a file path returns the file content as paginated lines. Use 'type: true' to fetch only the node type (FILE/DIRECTORY/SUBMODULE).",
+  bitbucketToolSchemas.browseRepository,
+  async ({ projectKey, repositorySlug, path, at, type, blame }) => {
+    const result = await bitbucketService.browseRepository(projectKey, repositorySlug, path, at, type, blame);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
   "bitbucket_getPullRequests",
   "Get pull requests for a Bitbucket repository",
   bitbucketToolSchemas.getPullRequests,


### PR DESCRIPTION
Closes #37

## Summary

Adds two read-only Bitbucket MCP tools for reading repository content directly — Tier 1 gap. Previously an agent could only see diffs inside a PR; it could not read an arbitrary source file or list a directory without cloning.

| Tool | Endpoint | Notes |
|---|---|---|
| `bitbucket_getFileContent` | `GET .../repos/{slug}/raw/{path}` | Raw text of a file at an optional ref/commit (`at`) |
| `bitbucket_browseRepository` | `GET .../repos/{slug}/browse/{path}` | Root/dir listing, file lines, or node type (`type: true`); optional `blame` |

Both default to the repository's default branch when `at` is omitted. No client regeneration needed — uses the existing `RepositoryService.streamRaw` / `getContent1`.

## Testing

- Unit tests added (default params, `at`/`type`/`blame` pass-through, error paths). Full bitbucket suite green (141 tests).
- Verified against a live Bitbucket Data Center instance: `browseRepository` listed the repo root and a file's lines and returned `{type: FILE}` for `type: true`; `getFileContent` returned the raw file text.