### PR TITLE
feat(bitbucket): add commit inspection tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { PullRequestsService, RepositoryService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,12 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  RepositoryService: {
+    getCommit: jest.fn(),
+    streamDiff: jest.fn(),
+    streamCommits: jest.fn(),
+    streamChanges: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -135,6 +141,169 @@ describe('BitbucketService', () => {
         mockPullRequestId
       );
 
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('getCommit', () => {
+    it('should successfully get a single commit', async () => {
+      const mockCommit = { id: 'abc123', message: 'Initial commit', author: { name: 'dev' } };
+      (RepositoryService.getCommit as jest.Mock).mockResolvedValue(mockCommit);
+
+      const result = await bitbucketService.getCommit(mockProjectKey, mockRepositorySlug, 'abc123');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockCommit);
+      expect(RepositoryService.getCommit).toHaveBeenCalledWith(
+        mockProjectKey,
+        'abc123',
+        mockRepositorySlug,
+        undefined
+      );
+    });
+
+    it('should pass the path through', async () => {
+      (RepositoryService.getCommit as jest.Mock).mockResolvedValue({});
+      await bitbucketService.getCommit(mockProjectKey, mockRepositorySlug, 'abc123', 'src/app.js');
+      expect(RepositoryService.getCommit).toHaveBeenCalledWith(
+        mockProjectKey,
+        'abc123',
+        mockRepositorySlug,
+        'src/app.js'
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (RepositoryService.getCommit as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.getCommit(mockProjectKey, mockRepositorySlug, 'abc123');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('getCommitDiff', () => {
+    it('should get a whole-commit diff by default (empty path)', async () => {
+      const mockDiff = { diffs: [] };
+      (RepositoryService.streamDiff as jest.Mock).mockResolvedValue(mockDiff);
+
+      const result = await bitbucketService.getCommitDiff(mockProjectKey, mockRepositorySlug, 'abc123');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockDiff);
+      expect(RepositoryService.streamDiff).toHaveBeenCalledWith(
+        'abc123',
+        mockRepositorySlug,
+        '',
+        mockProjectKey,
+        undefined, // srcPath
+        undefined, // avatarSize
+        undefined, // filter
+        undefined, // avatarScheme
+        undefined, // contextLines
+        undefined, // autoSrcPath
+        undefined, // whitespace
+        undefined, // withComments
+        undefined  // since
+      );
+    });
+
+    it('should pass path, contextLines, whitespace and srcPath through', async () => {
+      (RepositoryService.streamDiff as jest.Mock).mockResolvedValue({});
+      await bitbucketService.getCommitDiff(
+        mockProjectKey,
+        mockRepositorySlug,
+        'abc123',
+        'src/app.js',
+        '5',
+        'ignore-all',
+        'src/old.js'
+      );
+      expect(RepositoryService.streamDiff).toHaveBeenCalledWith(
+        'abc123',
+        mockRepositorySlug,
+        'src/app.js',
+        mockProjectKey,
+        'src/old.js',
+        undefined,
+        undefined,
+        undefined,
+        '5',
+        undefined,
+        'ignore-all',
+        undefined,
+        undefined
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (RepositoryService.streamDiff as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.getCommitDiff(mockProjectKey, mockRepositorySlug, 'abc123');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('compareRefs', () => {
+    it('should compare commits by default', async () => {
+      const mockCompare = { values: [{ id: 'c1' }], isLastPage: true };
+      (RepositoryService.streamCommits as jest.Mock).mockResolvedValue(mockCompare);
+
+      const result = await bitbucketService.compareRefs(
+        mockProjectKey,
+        mockRepositorySlug,
+        'refs/heads/feature',
+        'refs/heads/master'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockCompare);
+      expect(RepositoryService.streamCommits).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockRepositorySlug,
+        undefined, // fromRepo
+        'refs/heads/feature',
+        'refs/heads/master',
+        undefined, // start
+        25
+      );
+      expect(RepositoryService.streamChanges).not.toHaveBeenCalled();
+    });
+
+    it('should compare changes when compareType is changes', async () => {
+      const mockCompare = { values: [], isLastPage: true };
+      (RepositoryService.streamChanges as jest.Mock).mockResolvedValue(mockCompare);
+
+      await bitbucketService.compareRefs(
+        mockProjectKey,
+        mockRepositorySlug,
+        'refs/heads/feature',
+        'refs/heads/master',
+        'OTHER/repo',
+        'changes',
+        10,
+        50
+      );
+
+      expect(RepositoryService.streamChanges).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockRepositorySlug,
+        'OTHER/repo',
+        'refs/heads/feature',
+        'refs/heads/master',
+        10,
+        50
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (RepositoryService.streamCommits as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.compareRefs(
+        mockProjectKey,
+        mockRepositorySlug,
+        'a',
+        'b'
+      );
       expect(result.success).toBe(false);
       expect(result.error).toBe('API Error');
     });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -79,6 +79,98 @@ export class BitbucketService {
   }
 
   /**
+   * Get a single commit by id
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param commitId The commit id (hash) to retrieve
+   * @param path Optional path; if given, the commit is only returned if it affects this path
+   * @returns Promise with the commit data
+   */
+  async getCommit(projectKey: string, repositorySlug: string, commitId: string, path?: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.getCommit(projectKey, commitId, repositorySlug, path),
+      'Error fetching commit'
+    );
+  }
+
+  /**
+   * Get the diff of a single commit
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param commitId The commit id (hash)
+   * @param path Optional file path to limit the diff to; omit for the whole-commit diff
+   * @param contextLines Optional number of context lines around changes
+   * @param whitespace Optional whitespace flag (e.g. 'ignore-all')
+   * @param srcPath Optional previous path if the file was copied/moved/renamed
+   * @returns Promise with the commit diff
+   */
+  async getCommitDiff(
+    projectKey: string,
+    repositorySlug: string,
+    commitId: string,
+    path: string = '',
+    contextLines?: string,
+    whitespace?: string,
+    srcPath?: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.streamDiff(
+        commitId,
+        repositorySlug,
+        path,
+        projectKey,
+        srcPath,
+        undefined, // avatarSize
+        undefined, // filter
+        undefined, // avatarScheme
+        contextLines,
+        undefined, // autoSrcPath
+        whitespace,
+        undefined, // withComments
+        undefined  // since
+      ),
+      'Error fetching commit diff'
+    );
+  }
+
+  /**
+   * Compare two refs (commits or changes)
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param from The source ref/commit to compare from
+   * @param to The target ref/commit to compare to
+   * @param fromRepo Optional repository (projectKey/repositorySlug) the 'from' ref lives in, for cross-repo compares
+   * @param compareType 'commits' (default) to list commits between the refs, or 'changes' to list changed files
+   * @param start Optional pagination start
+   * @param limit Optional pagination limit (defaults to the package page size)
+   * @returns Promise with the comparison data
+   */
+  async compareRefs(
+    projectKey: string,
+    repositorySlug: string,
+    from: string,
+    to: string,
+    fromRepo?: string,
+    compareType: 'commits' | 'changes' = 'commits',
+    start?: number,
+    limit?: number
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const pageSize = limit ?? this.getPageSize();
+    return handleApiOperation(
+      () => compareType === 'changes'
+        ? RepositoryService.streamChanges(projectKey, repositorySlug, fromRepo, from, to, start, pageSize)
+        : RepositoryService.streamCommits(projectKey, repositorySlug, fromRepo, from, to, start, pageSize),
+      'Error comparing refs'
+    );
+  }
+
+  /**
    * Get a list of projects
    * @param name Optional filter by project name
    * @param permission Optional filter by permission
@@ -881,6 +973,31 @@ export const bitbucketToolSchemas = {
     path: z.string().optional().describe("Optional path to filter commits by"),
     since: z.string().optional().describe("The commit ID (exclusively) to retrieve commits after"),
     until: z.string().optional().describe("The commit ID (inclusively) to retrieve commits before"),
+    limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  getCommit: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    commitId: z.string().describe("The commit id (hash) to retrieve"),
+    path: z.string().optional().describe("Optional path; the commit is only returned if it affects this path")
+  },
+  getCommitDiff: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    commitId: z.string().describe("The commit id (hash)"),
+    path: z.string().optional().describe("Optional file path to limit the diff to. Omit for the whole-commit diff."),
+    contextLines: z.string().optional().describe("Number of context lines to include around changes"),
+    whitespace: z.string().optional().describe("Optional whitespace flag which can be set to 'ignore-all'"),
+    srcPath: z.string().optional().describe("The previous path to the file, if it has been copied, moved or renamed")
+  },
+  compareRefs: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    from: z.string().describe("The source ref or commit to compare from (e.g. 'refs/heads/feature' or a commit hash)"),
+    to: z.string().describe("The target ref or commit to compare to (e.g. 'refs/heads/master')"),
+    fromRepo: z.string().optional().describe("Optional 'projectKey/repositorySlug' the 'from' ref lives in, for cross-repository comparisons"),
+    compareType: z.enum(['commits', 'changes']).optional().describe("'commits' (default) lists the commits between the refs; 'changes' lists the changed files"),
+    start: z.number().optional().describe("Start number for pagination"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
   },
   getPullRequestComments: {

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -78,6 +78,36 @@ server.tool(
 );
 
 server.tool(
+  "bitbucket_getCommit",
+  "Get a single commit by its id (hash) from a Bitbucket repository. Returns author, message, parents, and timestamps.",
+  bitbucketToolSchemas.getCommit,
+  async ({ projectKey, repositorySlug, commitId, path }) => {
+    const result = await bitbucketService.getCommit(projectKey, repositorySlug, commitId, path);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_getCommitDiff",
+  "Get the diff of a single commit in a Bitbucket repository. Pass 'path' to limit the diff to one file, or omit it for the whole-commit diff.",
+  bitbucketToolSchemas.getCommitDiff,
+  async ({ projectKey, repositorySlug, commitId, path, contextLines, whitespace, srcPath }) => {
+    const result = await bitbucketService.getCommitDiff(projectKey, repositorySlug, commitId, path, contextLines, whitespace, srcPath);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_compareRefs",
+  "Compare two refs/commits in a Bitbucket repository. compareType 'commits' (default) lists the commits between them; 'changes' lists the changed files. Supports cross-repository comparison via fromRepo.",
+  bitbucketToolSchemas.compareRefs,
+  async ({ projectKey, repositorySlug, from, to, fromRepo, compareType, start, limit }) => {
+    const result = await bitbucketService.compareRefs(projectKey, repositorySlug, from, to, fromRepo, compareType, start, limit);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
   "bitbucket_getPullRequests",
   "Get pull requests for a Bitbucket repository",
   bitbucketToolSchemas.getPullRequests,


### PR DESCRIPTION
## Summary

Adds three read-only Bitbucket MCP tools for inspecting commits — Tier 2. Previously only a paginated commit list (`bitbucket_getCommits`) was available; there was no way to fetch a single commit, its diff, or to compare two refs.

| Tool | Endpoint | Notes |
|---|---|---|
| `bitbucket_getCommit` | `GET .../repos/{slug}/commits/{id}` | Single commit by id; optional `path` filter |
| `bitbucket_getCommitDiff` | `GET .../repos/{slug}/commits/{id}/diff/{path}` | Whole-commit diff (empty path) or a single file; `contextLines`/`whitespace`/`srcPath` |
| `bitbucket_compareRefs` | `GET .../repos/{slug}/compare/commits` \| `/compare/changes` | `compareType: commits` (default) or `changes`; cross-repo via `fromRepo` |

No client regeneration needed — uses the existing `RepositoryService.getCommit` / `streamDiff` / `streamCommits` / `streamChanges`.

## Testing

- Unit tests added (default + full param pass-through, `compareType` switch, error paths). Full bitbucket suite green (144 tests).
- Verified against a live Bitbucket Data Center instance: `getCommit` returned the commit, `getCommitDiff` returned the whole-commit diff, and `compareRefs` returned 2 commits / 1 changed file between diverging refs.