### PR TITLE
feat(bitbucket): add branch create/delete tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { PullRequestsService, RepositoryService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,10 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  RepositoryService: {
+    createBranch: jest.fn(),
+    deleteBranch: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -135,6 +139,90 @@ describe('BitbucketService', () => {
         mockPullRequestId
       );
 
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('createBranch', () => {
+    it('should successfully create a branch', async () => {
+      const mockBranch = { id: 'refs/heads/feature/login', displayId: 'feature/login' };
+      (RepositoryService.createBranch as jest.Mock).mockResolvedValue(mockBranch);
+
+      const result = await bitbucketService.createBranch(
+        mockProjectKey,
+        mockRepositorySlug,
+        'feature/login',
+        'refs/heads/master'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockBranch);
+      expect(RepositoryService.createBranch).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockRepositorySlug,
+        { name: 'feature/login', startPoint: 'refs/heads/master' }
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (RepositoryService.createBranch as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.createBranch(
+        mockProjectKey,
+        mockRepositorySlug,
+        'feature/login',
+        'refs/heads/master'
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('deleteBranch', () => {
+    it('should successfully delete a branch', async () => {
+      (RepositoryService.deleteBranch as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.deleteBranch(
+        mockProjectKey,
+        mockRepositorySlug,
+        'refs/heads/feature/login'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ deleted: true, name: 'refs/heads/feature/login' });
+      expect(RepositoryService.deleteBranch).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockRepositorySlug,
+        { name: 'refs/heads/feature/login' }
+      );
+    });
+
+    it('should pass dryRun through and report not-deleted', async () => {
+      (RepositoryService.deleteBranch as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.deleteBranch(
+        mockProjectKey,
+        mockRepositorySlug,
+        'refs/heads/feature/login',
+        true
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ deleted: false, name: 'refs/heads/feature/login' });
+      expect(RepositoryService.deleteBranch).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockRepositorySlug,
+        { name: 'refs/heads/feature/login', dryRun: true }
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (RepositoryService.deleteBranch as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.deleteBranch(
+        mockProjectKey,
+        mockRepositorySlug,
+        'refs/heads/feature/login'
+      );
       expect(result.success).toBe(false);
       expect(result.error).toBe('API Error');
     });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -137,6 +137,45 @@ export class BitbucketService {
   }
 
   /**
+   * Create a branch in a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param name The name of the new branch (e.g. 'feature/login')
+   * @param startPoint The commit hash or ref to branch from (e.g. 'refs/heads/master' or a commit id)
+   * @returns Promise with the created branch
+   */
+  async createBranch(projectKey: string, repositorySlug: string, name: string, startPoint: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.createBranch(projectKey, repositorySlug, { name, startPoint }),
+      'Error creating branch'
+    );
+  }
+
+  /**
+   * Delete a branch in a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param name The branch to delete (e.g. 'refs/heads/feature/login' or the branch name)
+   * @param dryRun If true, validate the deletion without actually removing the branch
+   * @returns Promise resolving to an acknowledgement
+   */
+  async deleteBranch(projectKey: string, repositorySlug: string, name: string, dryRun?: boolean) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody: any = { name, ...(dryRun !== undefined ? { dryRun } : {}) };
+    const result = await handleApiOperation(
+      () => RepositoryService.deleteBranch(projectKey, repositorySlug, requestBody),
+      'Error deleting branch'
+    );
+    if (result.success) {
+      return { ...result, data: { deleted: !dryRun, name } };
+    }
+    return result;
+  }
+
+  /**
    * Get pull requests for a repository
    * @param projectKey The project key
    * @param repositorySlug The repository slug
@@ -874,6 +913,18 @@ export const bitbucketToolSchemas = {
   getRepository: {
     projectKey: z.string().describe("The project key"),
     repositorySlug: z.string().describe("The repository slug")
+  },
+  createBranch: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    name: z.string().describe("The name of the new branch (e.g. 'feature/login')"),
+    startPoint: z.string().describe("The commit hash or ref to branch from (e.g. 'refs/heads/master' or a commit id)")
+  },
+  deleteBranch: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    name: z.string().describe("The branch to delete, as a full ref (e.g. 'refs/heads/feature/login') or branch name"),
+    dryRun: z.boolean().optional().describe("If true, validate the deletion without actually removing the branch")
   },
   getCommits: {
     projectKey: z.string().describe("The project key"),

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -68,6 +68,26 @@ server.tool(
 );
 
 server.tool(
+  "bitbucket_createBranch",
+  "Create a branch in a Bitbucket repository from a given start point (ref or commit). Useful to start a feature branch before opening a pull request.",
+  bitbucketToolSchemas.createBranch,
+  async ({ projectKey, repositorySlug, name, startPoint }) => {
+    const result = await bitbucketService.createBranch(projectKey, repositorySlug, name, startPoint);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_deleteBranch",
+  "Delete a branch in a Bitbucket repository. Pass dryRun: true to validate the deletion without performing it. WARNING: deleting a branch is irreversible once performed.",
+  bitbucketToolSchemas.deleteBranch,
+  async ({ projectKey, repositorySlug, name, dryRun }) => {
+    const result = await bitbucketService.deleteBranch(projectKey, repositorySlug, name, dryRun);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
   "bitbucket_getCommits",
   "Get commits for a Bitbucket repository",
   bitbucketToolSchemas.getCommits,


### PR DESCRIPTION
## Summary

Adds two Bitbucket MCP tools for branch mutations — Tier 2. Complements the read-only branch listing added earlier; agents can now create and delete branches.

| Tool | Endpoint | Notes |
|---|---|---|
| `bitbucket_createBranch` | `POST /rest/branch-utils/.../branches` | `name` + `startPoint` (ref or commit) |
| `bitbucket_deleteBranch` | `DELETE /rest/branch-utils/.../branches` | `name` (full ref); optional `dryRun` to validate without deleting |

No client regeneration needed — uses the existing `RepositoryService.createBranch` / `deleteBranch` (branch-utils API).

## Testing

- Unit tests added (create, delete, `dryRun` pass-through, error paths). Full bitbucket suite green (140 tests).
- Verified against a live Bitbucket Data Center instance: created `test/tmp` from `refs/heads/master` (HTTP 201, appears in branch list), then deleted it (HTTP 204, gone from list).