### PR TITLE
feat(bitbucket): add tag tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { PullRequestsService, RepositoryService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,11 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  RepositoryService: {
+    getTags: jest.fn(),
+    getTag: jest.fn(),
+    createTagForRepository: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -135,6 +140,120 @@ describe('BitbucketService', () => {
         mockPullRequestId
       );
 
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('getTags', () => {
+    it('should get tags with default parameters', async () => {
+      const mockTags = { values: [{ id: 'refs/tags/v1', displayId: 'v1' }], isLastPage: true };
+      (RepositoryService.getTags as jest.Mock).mockResolvedValue(mockTags);
+
+      const result = await bitbucketService.getTags(mockProjectKey, mockRepositorySlug);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockTags);
+      expect(RepositoryService.getTags).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockRepositorySlug,
+        undefined, // orderBy
+        undefined, // filterText
+        undefined, // start
+        25
+      );
+    });
+
+    it('should pass filterText, orderBy and pagination through', async () => {
+      (RepositoryService.getTags as jest.Mock).mockResolvedValue({ values: [] });
+      await bitbucketService.getTags(mockProjectKey, mockRepositorySlug, 'rel', 'MODIFICATION', 5, 50);
+      expect(RepositoryService.getTags).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockRepositorySlug,
+        'MODIFICATION',
+        'rel',
+        5,
+        50
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (RepositoryService.getTags as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.getTags(mockProjectKey, mockRepositorySlug);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('getTag', () => {
+    it('should get a single tag by name', async () => {
+      const mockTag = { id: 'refs/tags/v1', displayId: 'v1' };
+      (RepositoryService.getTag as jest.Mock).mockResolvedValue(mockTag);
+
+      const result = await bitbucketService.getTag(mockProjectKey, mockRepositorySlug, 'v1');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockTag);
+      expect(RepositoryService.getTag).toHaveBeenCalledWith(
+        mockProjectKey,
+        'v1',
+        mockRepositorySlug
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (RepositoryService.getTag as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.getTag(mockProjectKey, mockRepositorySlug, 'v1');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('createTag', () => {
+    it('should create a lightweight tag', async () => {
+      const mockTag = { id: 'refs/tags/v2', displayId: 'v2' };
+      (RepositoryService.createTagForRepository as jest.Mock).mockResolvedValue(mockTag);
+
+      const result = await bitbucketService.createTag(
+        mockProjectKey,
+        mockRepositorySlug,
+        'v2',
+        'refs/heads/master'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockTag);
+      expect(RepositoryService.createTagForRepository).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockRepositorySlug,
+        { name: 'v2', startPoint: 'refs/heads/master' }
+      );
+    });
+
+    it('should include message for an annotated tag', async () => {
+      (RepositoryService.createTagForRepository as jest.Mock).mockResolvedValue({});
+      await bitbucketService.createTag(
+        mockProjectKey,
+        mockRepositorySlug,
+        'v2',
+        'abc123',
+        'Release 2'
+      );
+      expect(RepositoryService.createTagForRepository).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockRepositorySlug,
+        { name: 'v2', startPoint: 'abc123', message: 'Release 2' }
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (RepositoryService.createTagForRepository as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.createTag(
+        mockProjectKey,
+        mockRepositorySlug,
+        'v2',
+        'refs/heads/master'
+      );
       expect(result.success).toBe(false);
       expect(result.error).toBe('API Error');
     });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -137,6 +137,73 @@ export class BitbucketService {
   }
 
   /**
+   * Get tags for a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param filterText Optional text the tag name must contain
+   * @param orderBy Optional ordering: ALPHABETICAL or MODIFICATION
+   * @param start Optional pagination start
+   * @param limit Optional pagination limit (defaults to the package page size)
+   * @returns Promise with tags data
+   */
+  async getTags(
+    projectKey: string,
+    repositorySlug: string,
+    filterText?: string,
+    orderBy?: string,
+    start?: number,
+    limit?: number
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.getTags(projectKey, repositorySlug, orderBy, filterText, start, limit ?? this.getPageSize()),
+      'Error fetching tags'
+    );
+  }
+
+  /**
+   * Get a single tag by name
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param name The tag name (e.g. 'release-1.0.0')
+   * @returns Promise with the tag data
+   */
+  async getTag(projectKey: string, repositorySlug: string, name: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.getTag(projectKey, name, repositorySlug),
+      'Error fetching tag'
+    );
+  }
+
+  /**
+   * Create a tag in a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param name The name of the new tag
+   * @param startPoint The commit hash or ref the tag should point at
+   * @param message Optional annotated-tag message
+   * @returns Promise with the created tag
+   */
+  async createTag(
+    projectKey: string,
+    repositorySlug: string,
+    name: string,
+    startPoint: string,
+    message?: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody: any = { name, startPoint, ...(message ? { message } : {}) };
+    return handleApiOperation(
+      () => RepositoryService.createTagForRepository(projectKey, repositorySlug, requestBody),
+      'Error creating tag'
+    );
+  }
+
+  /**
    * Get pull requests for a repository
    * @param projectKey The project key
    * @param repositorySlug The repository slug
@@ -874,6 +941,26 @@ export const bitbucketToolSchemas = {
   getRepository: {
     projectKey: z.string().describe("The project key"),
     repositorySlug: z.string().describe("The repository slug")
+  },
+  getTags: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    filterText: z.string().optional().describe("Optional text that the returned tag names must contain"),
+    orderBy: z.enum(['ALPHABETICAL', 'MODIFICATION']).optional().describe("Ordering of the results: ALPHABETICAL or MODIFICATION (most recently modified first)"),
+    start: z.number().optional().describe("Start number for pagination"),
+    limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  getTag: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    name: z.string().describe("The tag name (e.g. 'release-1.0.0')")
+  },
+  createTag: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    name: z.string().describe("The name of the new tag"),
+    startPoint: z.string().describe("The commit hash or ref the tag should point at (e.g. 'refs/heads/master' or a commit id)"),
+    message: z.string().optional().describe("Optional message; when provided, an annotated tag is created")
   },
   getCommits: {
     projectKey: z.string().describe("The project key"),

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -68,6 +68,36 @@ server.tool(
 );
 
 server.tool(
+  "bitbucket_getTags",
+  "Get tags for a Bitbucket repository. Supports filtering by name substring and ordering (ALPHABETICAL or MODIFICATION).",
+  bitbucketToolSchemas.getTags,
+  async ({ projectKey, repositorySlug, filterText, orderBy, start, limit }) => {
+    const result = await bitbucketService.getTags(projectKey, repositorySlug, filterText, orderBy, start, limit);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_getTag",
+  "Get a single tag by name from a Bitbucket repository.",
+  bitbucketToolSchemas.getTag,
+  async ({ projectKey, repositorySlug, name }) => {
+    const result = await bitbucketService.getTag(projectKey, repositorySlug, name);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_createTag",
+  "Create a tag in a Bitbucket repository pointing at a ref or commit. Provide a message to create an annotated tag.",
+  bitbucketToolSchemas.createTag,
+  async ({ projectKey, repositorySlug, name, startPoint, message }) => {
+    const result = await bitbucketService.createTag(projectKey, repositorySlug, name, startPoint, message);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
   "bitbucket_getCommits",
   "Get commits for a Bitbucket repository",
   bitbucketToolSchemas.getCommits,


### PR DESCRIPTION
## Summary

Adds three Bitbucket MCP tools for tags — Tier 2.

| Tool | Endpoint | Notes |
|---|---|---|
| `bitbucket_getTags` | `GET .../repos/{slug}/tags` | Optional `filterText` + `orderBy` (`ALPHABETICAL`/`MODIFICATION`), paginated |
| `bitbucket_getTag` | `GET .../repos/{slug}/tags/{name}` | Single tag by name |
| `bitbucket_createTag` | `POST .../repos/{slug}/tags` | `name` + `startPoint`; optional `message` for an annotated tag |

No client regeneration needed — uses the existing `RepositoryService.getTags` / `getTag` / `createTagForRepository`.

## Testing

- Unit tests added (defaults, filter/order pass-through, lightweight + annotated create, error paths). Full bitbucket suite green (143 tests).
- Verified against a live Bitbucket Data Center instance: created tag `v-test` at `refs/heads/master` (HTTP 200), then found it via `getTags` and fetched it via `getTag`.