### PR TITLE
feat(bitbucket): add build status tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { BuildsAndDeploymentsService, DeprecatedService, PullRequestsService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,13 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  DeprecatedService: {
+    getBuildStatus: jest.fn()
+  },
+  BuildsAndDeploymentsService: {
+    add: jest.fn(),
+    get: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -135,6 +142,125 @@ describe('BitbucketService', () => {
         mockPullRequestId
       );
 
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('listBuildStatuses', () => {
+    it('should list build statuses for a commit', async () => {
+      const mockStatuses = { values: [{ key: 'build-1', state: 'SUCCESSFUL' }], isLastPage: true };
+      (DeprecatedService.getBuildStatus as jest.Mock).mockResolvedValue(mockStatuses);
+
+      const result = await bitbucketService.listBuildStatuses('abc123');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockStatuses);
+      expect(DeprecatedService.getBuildStatus).toHaveBeenCalledWith('abc123', undefined, undefined, 25);
+    });
+
+    it('should pass orderBy and pagination through', async () => {
+      (DeprecatedService.getBuildStatus as jest.Mock).mockResolvedValue({ values: [] });
+      await bitbucketService.listBuildStatuses('abc123', 'newest', 5, 50);
+      expect(DeprecatedService.getBuildStatus).toHaveBeenCalledWith('abc123', 'newest', 5, 50);
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (DeprecatedService.getBuildStatus as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.listBuildStatuses('abc123');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('addBuildStatus', () => {
+    it('should add a build status with minimal fields', async () => {
+      (BuildsAndDeploymentsService.add as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.addBuildStatus(
+        mockProjectKey,
+        mockRepositorySlug,
+        'abc123',
+        'SUCCESSFUL',
+        'build-1',
+        'http://ci/build/1'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ added: true, commitId: 'abc123', key: 'build-1' });
+      expect(BuildsAndDeploymentsService.add).toHaveBeenCalledWith(
+        mockProjectKey,
+        'abc123',
+        mockRepositorySlug,
+        { state: 'SUCCESSFUL', key: 'build-1', url: 'http://ci/build/1' }
+      );
+    });
+
+    it('should include optional name and description', async () => {
+      (BuildsAndDeploymentsService.add as jest.Mock).mockResolvedValue(undefined);
+      await bitbucketService.addBuildStatus(
+        mockProjectKey,
+        mockRepositorySlug,
+        'abc123',
+        'FAILED',
+        'build-2',
+        'http://ci/build/2',
+        'Unit tests',
+        'Failed on step 3'
+      );
+      expect(BuildsAndDeploymentsService.add).toHaveBeenCalledWith(
+        mockProjectKey,
+        'abc123',
+        mockRepositorySlug,
+        { state: 'FAILED', key: 'build-2', url: 'http://ci/build/2', name: 'Unit tests', description: 'Failed on step 3' }
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (BuildsAndDeploymentsService.add as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.addBuildStatus(
+        mockProjectKey,
+        mockRepositorySlug,
+        'abc123',
+        'SUCCESSFUL',
+        'build-1',
+        'http://ci/build/1'
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('getBuildStatus', () => {
+    it('should get a single build status by key', async () => {
+      const mockStatus = { key: 'build-1', state: 'SUCCESSFUL' };
+      (BuildsAndDeploymentsService.get as jest.Mock).mockResolvedValue(mockStatus);
+
+      const result = await bitbucketService.getBuildStatus(
+        mockProjectKey,
+        mockRepositorySlug,
+        'abc123',
+        'build-1'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockStatus);
+      expect(BuildsAndDeploymentsService.get).toHaveBeenCalledWith(
+        mockProjectKey,
+        'abc123',
+        mockRepositorySlug,
+        'build-1'
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (BuildsAndDeploymentsService.get as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.getBuildStatus(
+        mockProjectKey,
+        mockRepositorySlug,
+        'abc123',
+        'build-1'
+      );
       expect(result.success).toBe(false);
       expect(result.error).toBe('API Error');
     });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { OpenAPI, ProjectService, PullRequestsService, RepositoryService } from './bitbucket-client/index.js';
+import { BuildsAndDeploymentsService, DeprecatedService, OpenAPI, ProjectService, PullRequestsService, RepositoryService } from './bitbucket-client/index.js';
 import { request as __request } from './bitbucket-client/core/request.js';
 import { handleApiOperation, resolveOpenApiBase } from '@atlassian-dc-mcp/common';
 import { simplifyInboxPullRequests } from './inbox-pr-mapper.js';
@@ -75,6 +75,74 @@ export class BitbucketService {
         limit ?? this.getPageSize()
       ),
       'Error fetching commits'
+    );
+  }
+
+  /**
+   * List build statuses for a commit
+   * @param commitId The commit id (hash) whose build statuses to list
+   * @param orderBy Optional ordering of the results
+   * @param start Optional pagination start
+   * @param limit Optional pagination limit (defaults to the package page size)
+   * @returns Promise with the build statuses
+   * @remarks Uses the global (repository-agnostic) build-status API, keyed only by commit id.
+   */
+  async listBuildStatuses(commitId: string, orderBy?: string, start?: number, limit?: number) {
+    return handleApiOperation(
+      () => DeprecatedService.getBuildStatus(commitId, orderBy, start, limit ?? this.getPageSize()),
+      'Error fetching build statuses'
+    );
+  }
+
+  /**
+   * Add (or update) a build status for a commit
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param commitId The commit id (hash) to attach the build status to
+   * @param state The build state: SUCCESSFUL, FAILED, or INPROGRESS
+   * @param key A unique key identifying the build (e.g. the pipeline/plan key)
+   * @param url The URL to the build result
+   * @param name Optional display name for the build
+   * @param description Optional description for the build
+   * @returns Promise resolving to an acknowledgement
+   */
+  async addBuildStatus(
+    projectKey: string,
+    repositorySlug: string,
+    commitId: string,
+    state: 'SUCCESSFUL' | 'FAILED' | 'INPROGRESS',
+    key: string,
+    url: string,
+    name?: string,
+    description?: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody: any = { state, key, url, ...(name ? { name } : {}), ...(description ? { description } : {}) };
+    const result = await handleApiOperation(
+      () => BuildsAndDeploymentsService.add(projectKey, commitId, repositorySlug, requestBody),
+      'Error adding build status'
+    );
+    if (result.success) {
+      return { ...result, data: { added: true, commitId, key } };
+    }
+    return result;
+  }
+
+  /**
+   * Get a single build status for a commit by its key
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param commitId The commit id (hash)
+   * @param key The unique key of the build status to fetch
+   * @returns Promise with the build status
+   */
+  async getBuildStatus(projectKey: string, repositorySlug: string, commitId: string, key: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => BuildsAndDeploymentsService.get(projectKey, commitId, repositorySlug, key),
+      'Error fetching build status'
     );
   }
 
@@ -882,6 +950,28 @@ export const bitbucketToolSchemas = {
     since: z.string().optional().describe("The commit ID (exclusively) to retrieve commits after"),
     until: z.string().optional().describe("The commit ID (inclusively) to retrieve commits before"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  listBuildStatuses: {
+    commitId: z.string().describe("The commit id (hash) whose build statuses to list. Note: build statuses are keyed by commit id globally, independent of project/repository."),
+    orderBy: z.string().optional().describe("Optional ordering of the results"),
+    start: z.number().optional().describe("Start number for pagination"),
+    limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  addBuildStatus: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    commitId: z.string().describe("The commit id (hash) to attach the build status to"),
+    state: z.enum(['SUCCESSFUL', 'FAILED', 'INPROGRESS']).describe("The build state"),
+    key: z.string().describe("A unique key identifying the build (e.g. the pipeline or plan key)"),
+    url: z.string().describe("The URL to the build result"),
+    name: z.string().optional().describe("Optional display name for the build"),
+    description: z.string().optional().describe("Optional description for the build")
+  },
+  getBuildStatus: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    commitId: z.string().describe("The commit id (hash)"),
+    key: z.string().describe("The unique key of the build status to fetch")
   },
   getPullRequestComments: {
     projectKey: z.string().describe("The project key"),

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -78,6 +78,36 @@ server.tool(
 );
 
 server.tool(
+  "bitbucket_listBuildStatuses",
+  "List build statuses (CI results) for a commit. NOTE: build statuses are keyed globally by commit id, so this does not take a project/repository.",
+  bitbucketToolSchemas.listBuildStatuses,
+  async ({ commitId, orderBy, start, limit }) => {
+    const result = await bitbucketService.listBuildStatuses(commitId, orderBy, start, limit);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_addBuildStatus",
+  "Add (or update) a build status (CI result) on a commit. state is SUCCESSFUL, FAILED, or INPROGRESS; key uniquely identifies the build and url links to its result.",
+  bitbucketToolSchemas.addBuildStatus,
+  async ({ projectKey, repositorySlug, commitId, state, key, url, name, description }) => {
+    const result = await bitbucketService.addBuildStatus(projectKey, repositorySlug, commitId, state, key, url, name, description);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_getBuildStatus",
+  "Get a single build status for a commit by its key.",
+  bitbucketToolSchemas.getBuildStatus,
+  async ({ projectKey, repositorySlug, commitId, key }) => {
+    const result = await bitbucketService.getBuildStatus(projectKey, repositorySlug, commitId, key);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
   "bitbucket_getPullRequests",
   "Get pull requests for a Bitbucket repository",
   bitbucketToolSchemas.getPullRequests,


### PR DESCRIPTION
## Summary

Adds three Bitbucket MCP tools for commit build (CI) statuses — Tier 2. Lets agents read and post CI results on commits.

| Tool | Endpoint | Notes |
|---|---|---|
| `bitbucket_listBuildStatuses` | `GET /rest/build-status/.../commits/{id}` | List statuses for a commit (global, keyed by commit id only) |
| `bitbucket_addBuildStatus` | `POST .../repos/{slug}/commits/{id}/builds` | `state` (SUCCESSFUL/FAILED/INPROGRESS), `key`, `url`, optional `name`/`description` |
| `bitbucket_getBuildStatus` | `GET .../repos/{slug}/commits/{id}/builds?key=` | Single status by key |

Note: listing is only available on the global (repository-agnostic) build-status API, so `listBuildStatuses` takes only a commit id; add/get use the modern repo-scoped API. No client regeneration needed — uses the existing `DeprecatedService.getBuildStatus` and `BuildsAndDeploymentsService.add` / `get`.

## Testing

- Unit tests added (list defaults + pagination, add minimal + full, get, error paths). Full bitbucket suite green (143 tests).
- Verified against a live Bitbucket Data Center instance: added a `SUCCESSFUL` status (key `mcp-test`) to a commit (HTTP 204), then saw it via `listBuildStatuses` and fetched it via `getBuildStatus`.