### PR TITLE
feat(bitbucket): add commit comment tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { PullRequestsService, RepositoryService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,10 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  RepositoryService: {
+    getComments: jest.fn(),
+    createComment: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -135,6 +139,113 @@ describe('BitbucketService', () => {
         mockPullRequestId
       );
 
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('getCommitComments', () => {
+    it('should get commit comments for a path', async () => {
+      const mockComments = { values: [{ id: 1, text: 'looks good' }], isLastPage: true };
+      (RepositoryService.getComments as jest.Mock).mockResolvedValue(mockComments);
+
+      const result = await bitbucketService.getCommitComments(mockProjectKey, mockRepositorySlug, 'abc123', 'src/app.js');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockComments);
+      expect(RepositoryService.getComments).toHaveBeenCalledWith(
+        mockProjectKey,
+        'abc123',
+        mockRepositorySlug,
+        'src/app.js',
+        undefined, // since
+        undefined, // start
+        25
+      );
+    });
+
+    it('should pass since and pagination through', async () => {
+      (RepositoryService.getComments as jest.Mock).mockResolvedValue({ values: [] });
+      await bitbucketService.getCommitComments(mockProjectKey, mockRepositorySlug, 'abc123', 'src/app.js', 'def456', 5, 50);
+      expect(RepositoryService.getComments).toHaveBeenCalledWith(
+        mockProjectKey,
+        'abc123',
+        mockRepositorySlug,
+        'src/app.js',
+        'def456',
+        5,
+        50
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (RepositoryService.getComments as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.getCommitComments(mockProjectKey, mockRepositorySlug, 'abc123', 'src/app.js');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('addCommitComment', () => {
+    it('should add a general commit comment', async () => {
+      const mockComment = { id: 99, text: 'nice' };
+      (RepositoryService.createComment as jest.Mock).mockResolvedValue(mockComment);
+
+      const result = await bitbucketService.addCommitComment(mockProjectKey, mockRepositorySlug, 'abc123', 'nice');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockComment);
+      expect(RepositoryService.createComment).toHaveBeenCalledWith(
+        mockProjectKey,
+        'abc123',
+        mockRepositorySlug,
+        undefined,
+        { text: 'nice' }
+      );
+    });
+
+    it('should anchor the comment to a file and line', async () => {
+      (RepositoryService.createComment as jest.Mock).mockResolvedValue({ id: 100 });
+      await bitbucketService.addCommitComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        'abc123',
+        'fix this',
+        'src/app.js',
+        12,
+        'ADDED'
+      );
+      expect(RepositoryService.createComment).toHaveBeenCalledWith(
+        mockProjectKey,
+        'abc123',
+        mockRepositorySlug,
+        undefined,
+        { text: 'fix this', anchor: { path: 'src/app.js', line: 12, lineType: 'ADDED', fileType: 'TO' } }
+      );
+    });
+
+    it('should default lineType to CONTEXT when a line is given without one', async () => {
+      (RepositoryService.createComment as jest.Mock).mockResolvedValue({ id: 101 });
+      await bitbucketService.addCommitComment(
+        mockProjectKey,
+        mockRepositorySlug,
+        'abc123',
+        'note',
+        'src/app.js',
+        3
+      );
+      expect(RepositoryService.createComment).toHaveBeenCalledWith(
+        mockProjectKey,
+        'abc123',
+        mockRepositorySlug,
+        undefined,
+        { text: 'note', anchor: { path: 'src/app.js', line: 3, lineType: 'CONTEXT', fileType: 'TO' } }
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (RepositoryService.createComment as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.addCommitComment(mockProjectKey, mockRepositorySlug, 'abc123', 'x');
       expect(result.success).toBe(false);
       expect(result.error).toBe('API Error');
     });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -79,6 +79,69 @@ export class BitbucketService {
   }
 
   /**
+   * Get comments on a commit
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param commitId The commit id (hash)
+   * @param path The file path to return comments for (required by Bitbucket when retrieving commit comments)
+   * @param since Optional commit id; return comments added since that commit
+   * @param start Optional pagination start
+   * @param limit Optional pagination limit (defaults to the package page size)
+   * @returns Promise with the commit comments
+   */
+  async getCommitComments(
+    projectKey: string,
+    repositorySlug: string,
+    commitId: string,
+    path: string,
+    since?: string,
+    start?: number,
+    limit?: number
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.getComments(projectKey, commitId, repositorySlug, path, since, start, limit ?? this.getPageSize()),
+      'Error fetching commit comments'
+    );
+  }
+
+  /**
+   * Add a comment to a commit
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param commitId The commit id (hash) to comment on
+   * @param text The comment text
+   * @param path Optional file path to anchor the comment to a file
+   * @param line Optional line number within the file to anchor the comment to
+   * @param lineType Optional line type for the anchored line (ADDED, REMOVED, or CONTEXT)
+   * @returns Promise with the created comment
+   */
+  async addCommitComment(
+    projectKey: string,
+    repositorySlug: string,
+    commitId: string,
+    text: string,
+    path?: string,
+    line?: number,
+    lineType?: 'ADDED' | 'REMOVED' | 'CONTEXT'
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody: any = { text };
+    if (path) {
+      requestBody.anchor = {
+        path,
+        ...(line !== undefined ? { line, lineType: lineType ?? 'CONTEXT', fileType: 'TO' } : {}),
+      };
+    }
+    return handleApiOperation(
+      () => RepositoryService.createComment(projectKey, commitId, repositorySlug, undefined, requestBody),
+      'Error adding commit comment'
+    );
+  }
+
+  /**
    * Get a list of projects
    * @param name Optional filter by project name
    * @param permission Optional filter by permission
@@ -882,6 +945,24 @@ export const bitbucketToolSchemas = {
     since: z.string().optional().describe("The commit ID (exclusively) to retrieve commits after"),
     until: z.string().optional().describe("The commit ID (inclusively) to retrieve commits before"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  getCommitComments: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    commitId: z.string().describe("The commit id (hash)"),
+    path: z.string().describe("The file path to return comments for. Required: Bitbucket only returns commit comments scoped to a file path."),
+    since: z.string().optional().describe("Optional commit id; return comments added since that commit"),
+    start: z.number().optional().describe("Start number for pagination"),
+    limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  addCommitComment: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    commitId: z.string().describe("The commit id (hash) to comment on"),
+    text: z.string().describe("The comment text"),
+    path: z.string().optional().describe("Optional file path to anchor the comment to a file"),
+    line: z.number().optional().describe("Optional line number within the file to anchor the comment to (requires path)"),
+    lineType: z.enum(['ADDED', 'REMOVED', 'CONTEXT']).optional().describe("Line type for the anchored line. Defaults to CONTEXT when a line is given.")
   },
   getPullRequestComments: {
     projectKey: z.string().describe("The project key"),

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -78,6 +78,26 @@ server.tool(
 );
 
 server.tool(
+  "bitbucket_getCommitComments",
+  "Get comments on a commit in a Bitbucket repository. A file path is required — Bitbucket only returns commit comments scoped to a file.",
+  bitbucketToolSchemas.getCommitComments,
+  async ({ projectKey, repositorySlug, commitId, path, since, start, limit }) => {
+    const result = await bitbucketService.getCommitComments(projectKey, repositorySlug, commitId, path, since, start, limit);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_addCommitComment",
+  "Add a comment to a commit in a Bitbucket repository. Provide a path (and optionally a line) to anchor the comment to a file.",
+  bitbucketToolSchemas.addCommitComment,
+  async ({ projectKey, repositorySlug, commitId, text, path, line, lineType }) => {
+    const result = await bitbucketService.addCommitComment(projectKey, repositorySlug, commitId, text, path, line, lineType);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
   "bitbucket_getPullRequests",
   "Get pull requests for a Bitbucket repository",
   bitbucketToolSchemas.getPullRequests,


### PR DESCRIPTION
## Summary

Adds two Bitbucket MCP tools for commit comments — Tier 2.

| Tool | Endpoint | Notes |
|---|---|---|
| `bitbucket_getCommitComments` | `GET .../repos/{slug}/commits/{id}/comments` | **`path` is required** — Bitbucket only returns commit comments scoped to a file |
| `bitbucket_addCommitComment` | `POST .../repos/{slug}/commits/{id}/comments` | General comment, or anchored to a file (`path`) and optionally a `line`/`lineType` |

No client regeneration needed — uses the existing `RepositoryService.getComments` / `createComment`.

## Testing

- Unit tests added (path-scoped get, since/pagination, general + file/line-anchored add, lineType default, error paths). Full bitbucket suite green (142 tests).
- Verified against a live Bitbucket Data Center instance: added a file-anchored comment to `app.js` on a commit (HTTP 201), then retrieved it via `getCommitComments` with `path=app.js`. (Confirmed live that the GET requires `path`, which is reflected in the tool contract.)