### PR TITLE
feat(bitbucket): add granular PR reviewer tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -23,7 +23,9 @@ jest.mock('../bitbucket-client/index.js', () => ({
     updateStatus: jest.fn(),
     getPage: jest.fn(),
     getReviewers: jest.fn(),
-    get3: jest.fn()
+    get3: jest.fn(),
+    assignParticipantRole: jest.fn(),
+    unassignParticipantRole: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -135,6 +137,75 @@ describe('BitbucketService', () => {
         mockPullRequestId
       );
 
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('addPullRequestReviewer', () => {
+    it('should add a reviewer to a pull request', async () => {
+      const mockParticipant = { user: { name: 'reviewer1' }, role: 'REVIEWER' };
+      (PullRequestsService.assignParticipantRole as jest.Mock).mockResolvedValue(mockParticipant);
+
+      const result = await bitbucketService.addPullRequestReviewer(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        'reviewer1'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockParticipant);
+      expect(PullRequestsService.assignParticipantRole).toHaveBeenCalledWith(
+        mockProjectKey,
+        mockPullRequestId,
+        mockRepositorySlug,
+        { user: { name: 'reviewer1' }, role: 'REVIEWER' }
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (PullRequestsService.assignParticipantRole as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.addPullRequestReviewer(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        'reviewer1'
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('removePullRequestReviewer', () => {
+    it('should remove a reviewer from a pull request', async () => {
+      (PullRequestsService.unassignParticipantRole as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.removePullRequestReviewer(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        'reviewer1'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ removed: true, userSlug: 'reviewer1' });
+      expect(PullRequestsService.unassignParticipantRole).toHaveBeenCalledWith(
+        mockProjectKey,
+        'reviewer1',
+        mockPullRequestId,
+        mockRepositorySlug
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (PullRequestsService.unassignParticipantRole as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.removePullRequestReviewer(
+        mockProjectKey,
+        mockRepositorySlug,
+        mockPullRequestId,
+        'reviewer1'
+      );
       expect(result.success).toBe(false);
       expect(result.error).toBe('API Error');
     });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -824,6 +824,55 @@ export class BitbucketService {
     return result;
   }
 
+  /**
+   * Add a reviewer to a pull request
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param pullRequestId The pull request ID
+   * @param userSlug The username/name of the user to add as a reviewer
+   * @returns Promise with the participant details
+   */
+  async addPullRequestReviewer(
+    projectKey: string,
+    repositorySlug: string,
+    pullRequestId: string,
+    userSlug: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody: any = { user: { name: userSlug }, role: 'REVIEWER' };
+    return handleApiOperation(
+      () => PullRequestsService.assignParticipantRole(projectKey, pullRequestId, repositorySlug, requestBody),
+      'Error adding pull request reviewer'
+    );
+  }
+
+  /**
+   * Remove a reviewer from a pull request
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param pullRequestId The pull request ID
+   * @param userSlug The username/name of the reviewer to remove
+   * @returns Promise resolving to an acknowledgement
+   */
+  async removePullRequestReviewer(
+    projectKey: string,
+    repositorySlug: string,
+    pullRequestId: string,
+    userSlug: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const result = await handleApiOperation(
+      () => PullRequestsService.unassignParticipantRole(projectKey, userSlug, pullRequestId, repositorySlug),
+      'Error removing pull request reviewer'
+    );
+    if (result.success) {
+      return { ...result, data: { removed: true, userSlug } };
+    }
+    return result;
+  }
+
   async validateSetup(): Promise<void> {
     await __request(OpenAPI, {
       method: 'GET',
@@ -975,6 +1024,18 @@ export const bitbucketToolSchemas = {
     draft: z.boolean().optional().describe("If provided, sets the draft (work-in-progress) status of the pull request. Pass true to mark as draft, false to mark as ready for review."),
     reviewers: z.array(z.string()).optional().describe("Optional array of reviewer usernames to set (use the 'name' field from Bitbucket user objects, not 'slug')"),
     output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
+  },
+  addPullRequestReviewer: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID"),
+    userSlug: z.string().describe("The username/name of the user to add as a reviewer (use the 'name' field from Bitbucket user objects). Adds a single reviewer without replacing the existing ones, unlike bitbucket_updatePullRequest.")
+  },
+  removePullRequestReviewer: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID"),
+    userSlug: z.string().describe("The username/name of the reviewer to remove. The user remains a participant but loses the REVIEWER role.")
   },
   getRequiredReviewers: {
     projectKey: z.string().describe("The project key"),

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -157,6 +157,26 @@ server.tool(
   }
 );
 
+server.tool(
+  "bitbucket_addPullRequestReviewer",
+  "Add a single reviewer to a pull request without replacing existing reviewers (unlike bitbucket_updatePullRequest, which replaces the whole reviewer list). Resolve userSlug via bitbucket_getUser if needed.",
+  bitbucketToolSchemas.addPullRequestReviewer,
+  async ({ projectKey, repositorySlug, pullRequestId, userSlug }) => {
+    const result = await bitbucketService.addPullRequestReviewer(projectKey, repositorySlug, pullRequestId, userSlug);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_removePullRequestReviewer",
+  "Remove a reviewer from a pull request. The user remains a participant but loses the REVIEWER role.",
+  bitbucketToolSchemas.removePullRequestReviewer,
+  async ({ projectKey, repositorySlug, pullRequestId, userSlug }) => {
+    const result = await bitbucketService.removePullRequestReviewer(projectKey, repositorySlug, pullRequestId, userSlug);
+    return formatToolResponse(result);
+  }
+);
+
 
 server.tool(
   "bitbucket_getPullRequestDiff",


### PR DESCRIPTION
## Summary

Adds two Bitbucket MCP tools for managing individual pull request reviewers — Tier 2. These complement `bitbucket_updatePullRequest`, which can only replace the entire reviewer list; these add/remove one reviewer at a time.

| Tool | Endpoint | Notes |
|---|---|---|
| `bitbucket_addPullRequestReviewer` | `POST .../pull-requests/{id}/participants` | Adds a single reviewer (`{ user: { name }, role: REVIEWER }`) |
| `bitbucket_removePullRequestReviewer` | `DELETE .../pull-requests/{id}/participants/{userSlug}` | Removes the REVIEWER role; user stays a participant |

Note: `approve` / `needs-work` toggling is already covered by `bitbucket_submitPullRequestReview`, and PR tasks by blocker comments — this PR only adds the genuinely missing add/remove-reviewer operations. No client regeneration needed — uses the existing `PullRequestsService.assignParticipantRole` / `unassignParticipantRole`.

## Testing

- Unit tests added (add success + body shape, remove success + ack, error paths). Full bitbucket suite green (139 tests).
- Verified against a live Bitbucket Data Center instance: both endpoints are reachable and correctly parse the request (created a temp PR; `addPullRequestReviewer` and `removePullRequestReviewer` returned a semantic 409 — *"the author of a pull request may not be reassigned to another role"* — confirming routing/params/body are correct). The single-user test instance has no second user to fully exercise the success path, which is covered by the unit tests.