### PR TITLE
feat(bitbucket): add file edit/commit tool

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { PullRequestsService, RepositoryService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,9 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  RepositoryService: {
+    editFile: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -135,6 +138,65 @@ describe('BitbucketService', () => {
         mockPullRequestId
       );
 
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('editFile', () => {
+    it('should create a new file (no sourceCommitId)', async () => {
+      const mockCommit = { id: 'newsha', message: 'add file' };
+      (RepositoryService.editFile as jest.Mock).mockResolvedValue(mockCommit);
+
+      const result = await bitbucketService.editFile(
+        mockProjectKey,
+        mockRepositorySlug,
+        'docs/new.md',
+        '# Hello',
+        'add file',
+        'master'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockCommit);
+      expect(RepositoryService.editFile).toHaveBeenCalledWith(
+        'docs/new.md',
+        mockProjectKey,
+        mockRepositorySlug,
+        { content: '# Hello', message: 'add file', branch: 'master' }
+      );
+    });
+
+    it('should pass sourceCommitId and sourceBranch when editing', async () => {
+      (RepositoryService.editFile as jest.Mock).mockResolvedValue({ id: 'sha2' });
+      await bitbucketService.editFile(
+        mockProjectKey,
+        mockRepositorySlug,
+        'README.md',
+        'updated',
+        'edit readme',
+        'feature/x',
+        'oldsha',
+        'master'
+      );
+      expect(RepositoryService.editFile).toHaveBeenCalledWith(
+        'README.md',
+        mockProjectKey,
+        mockRepositorySlug,
+        { content: 'updated', message: 'edit readme', branch: 'feature/x', sourceCommitId: 'oldsha', sourceBranch: 'master' }
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (RepositoryService.editFile as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.editFile(
+        mockProjectKey,
+        mockRepositorySlug,
+        'README.md',
+        'x',
+        'msg',
+        'master'
+      );
       expect(result.success).toBe(false);
       expect(result.error).toBe('API Error');
     });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -137,6 +137,43 @@ export class BitbucketService {
   }
 
   /**
+   * Create or edit a file in a repository and commit the change
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param path The path of the file to create or modify
+   * @param content The full new content of the file
+   * @param message The commit message
+   * @param branch The branch to commit on (e.g. 'refs/heads/master' or 'master')
+   * @param sourceCommitId The commit id the file was last seen at; required when editing an existing file to detect conflicts. Omit for a new file.
+   * @param sourceBranch When set, creates `branch` from this starting branch before committing
+   * @returns Promise with the created commit
+   */
+  async editFile(
+    projectKey: string,
+    repositorySlug: string,
+    path: string,
+    content: string,
+    message: string,
+    branch: string,
+    sourceCommitId?: string,
+    sourceBranch?: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const formData: any = {
+      content,
+      message,
+      branch,
+      ...(sourceCommitId ? { sourceCommitId } : {}),
+      ...(sourceBranch ? { sourceBranch } : {}),
+    };
+    return handleApiOperation(
+      () => RepositoryService.editFile(path, projectKey, repositorySlug, formData),
+      'Error editing file'
+    );
+  }
+
+  /**
    * Get pull requests for a repository
    * @param projectKey The project key
    * @param repositorySlug The repository slug
@@ -874,6 +911,16 @@ export const bitbucketToolSchemas = {
   getRepository: {
     projectKey: z.string().describe("The project key"),
     repositorySlug: z.string().describe("The repository slug")
+  },
+  editFile: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    path: z.string().describe("The path of the file to create or modify (e.g. 'src/index.ts')"),
+    content: z.string().describe("The full new content of the file"),
+    message: z.string().describe("The commit message"),
+    branch: z.string().describe("The branch to commit on (e.g. 'master' or 'refs/heads/master')"),
+    sourceCommitId: z.string().optional().describe("The commit id the file was last seen at. Required when editing an existing file (conflict detection); omit when creating a new file."),
+    sourceBranch: z.string().optional().describe("When set, the target branch is created from this starting branch before committing.")
   },
   getCommits: {
     projectKey: z.string().describe("The project key"),

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -68,6 +68,16 @@ server.tool(
 );
 
 server.tool(
+  "bitbucket_editFile",
+  "Create or edit a file in a Bitbucket repository and commit the change in one call (no clone needed). For an existing file, pass sourceCommitId (the commit the file was last seen at) for conflict detection; omit it to create a new file. Returns the created commit.",
+  bitbucketToolSchemas.editFile,
+  async ({ projectKey, repositorySlug, path, content, message, branch, sourceCommitId, sourceBranch }) => {
+    const result = await bitbucketService.editFile(projectKey, repositorySlug, path, content, message, branch, sourceCommitId, sourceBranch);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
   "bitbucket_getCommits",
   "Get commits for a Bitbucket repository",
   bitbucketToolSchemas.getCommits,


### PR DESCRIPTION
## Summary

Adds `bitbucket_editFile` — create or modify a file and commit it in a single call, no clone required (Track A). This is the first write-to-repository tool; complements the read-only `bitbucket_getFileContent`/`bitbucket_browseRepository`.

| Tool | Endpoint | Notes |
|---|---|---|
| `bitbucket_editFile` | `PUT .../repos/{slug}/browse/{path}` (multipart) | `content`, `message`, `branch`; `sourceCommitId` for conflict detection on existing files; `sourceBranch` to branch off a start point. Returns the created commit. |

No client regeneration needed — uses the existing `RepositoryService.editFile`.

## Testing

- Unit tests added (new file, edit with sourceCommitId/sourceBranch, error path). Full bitbucket suite green (138 tests).
- Verified against a live Bitbucket Data Center instance: created a file on a new branch via the multipart PUT (HTTP 200, commit returned), read it back through `/raw` (content matched exactly), then cleaned up the branch.