### PR TITLE
feat(bitbucket): add Code Insights tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { BuildsAndDeploymentsService, PullRequestsService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,14 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  BuildsAndDeploymentsService: {
+    setACodeInsightsReport: jest.fn(),
+    getACodeInsightsReport: jest.fn(),
+    deleteACodeInsightsReport: jest.fn(),
+    addAnnotations: jest.fn(),
+    getAnnotations: jest.fn(),
+    deleteAnnotations: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -135,6 +143,85 @@ describe('BitbucketService', () => {
         mockPullRequestId
       );
 
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('Code Insights', () => {
+    const commitId = 'abc123';
+    const key = 'mycompany.eslint';
+
+    it('setInsightReport should PUT the report', async () => {
+      const mockReport = { key, title: 'ESLint' };
+      (BuildsAndDeploymentsService.setACodeInsightsReport as jest.Mock).mockResolvedValue(mockReport);
+      const report = { title: 'ESLint', result: 'PASS' };
+
+      const result = await bitbucketService.setInsightReport(mockProjectKey, mockRepositorySlug, commitId, key, report);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockReport);
+      expect(BuildsAndDeploymentsService.setACodeInsightsReport).toHaveBeenCalledWith(
+        mockProjectKey,
+        commitId,
+        mockRepositorySlug,
+        key,
+        report
+      );
+    });
+
+    it('getInsightReport should GET the report', async () => {
+      (BuildsAndDeploymentsService.getACodeInsightsReport as jest.Mock).mockResolvedValue({ key });
+      const result = await bitbucketService.getInsightReport(mockProjectKey, mockRepositorySlug, commitId, key);
+      expect(result.success).toBe(true);
+      expect(BuildsAndDeploymentsService.getACodeInsightsReport).toHaveBeenCalledWith(
+        mockProjectKey, commitId, mockRepositorySlug, key
+      );
+    });
+
+    it('deleteInsightReport should DELETE and ack', async () => {
+      (BuildsAndDeploymentsService.deleteACodeInsightsReport as jest.Mock).mockResolvedValue(undefined);
+      const result = await bitbucketService.deleteInsightReport(mockProjectKey, mockRepositorySlug, commitId, key);
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ deleted: true, key });
+    });
+
+    it('addInsightAnnotations should POST {annotations} and ack with count', async () => {
+      (BuildsAndDeploymentsService.addAnnotations as jest.Mock).mockResolvedValue(undefined);
+      const annotations = [
+        { externalId: 'a1', path: 'app.js', line: 3, message: 'x', severity: 'HIGH' },
+        { externalId: 'a2', path: 'app.js', line: 9, message: 'y', severity: 'LOW' }
+      ];
+      const result = await bitbucketService.addInsightAnnotations(mockProjectKey, mockRepositorySlug, commitId, key, annotations);
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ added: 2, key });
+      expect(BuildsAndDeploymentsService.addAnnotations).toHaveBeenCalledWith(
+        mockProjectKey, commitId, mockRepositorySlug, key, { annotations }
+      );
+    });
+
+    it('getInsightAnnotations should GET annotations', async () => {
+      (BuildsAndDeploymentsService.getAnnotations as jest.Mock).mockResolvedValue({ annotations: [] });
+      const result = await bitbucketService.getInsightAnnotations(mockProjectKey, mockRepositorySlug, commitId, key);
+      expect(result.success).toBe(true);
+      expect(BuildsAndDeploymentsService.getAnnotations).toHaveBeenCalledWith(
+        mockProjectKey, commitId, mockRepositorySlug, key
+      );
+    });
+
+    it('deleteInsightAnnotations should pass externalId and ack', async () => {
+      (BuildsAndDeploymentsService.deleteAnnotations as jest.Mock).mockResolvedValue(undefined);
+      const result = await bitbucketService.deleteInsightAnnotations(mockProjectKey, mockRepositorySlug, commitId, key, 'a1');
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ deleted: true, key, externalId: 'a1' });
+      expect(BuildsAndDeploymentsService.deleteAnnotations).toHaveBeenCalledWith(
+        mockProjectKey, commitId, mockRepositorySlug, key, 'a1'
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (BuildsAndDeploymentsService.getACodeInsightsReport as jest.Mock).mockRejectedValue(new Error('API Error'));
+      const result = await bitbucketService.getInsightReport(mockProjectKey, mockRepositorySlug, commitId, key);
       expect(result.success).toBe(false);
       expect(result.error).toBe('API Error');
     });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { OpenAPI, ProjectService, PullRequestsService, RepositoryService } from './bitbucket-client/index.js';
+import { BuildsAndDeploymentsService, OpenAPI, ProjectService, PullRequestsService, RepositoryService } from './bitbucket-client/index.js';
 import { request as __request } from './bitbucket-client/core/request.js';
 import { handleApiOperation, resolveOpenApiBase } from '@atlassian-dc-mcp/common';
 import { simplifyInboxPullRequests } from './inbox-pr-mapper.js';
@@ -76,6 +76,116 @@ export class BitbucketService {
       ),
       'Error fetching commits'
     );
+  }
+
+  /**
+   * Create or replace a Code Insights report on a commit
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param commitId The commit id (hash) the report is attached to
+   * @param key A unique key identifying the report (namespaced, e.g. 'mycompany.eslint')
+   * @param report The report payload (title required; optional details, result PASS/FAIL, reporter, link, logoUrl, data[])
+   * @returns Promise with the created report
+   */
+  async setInsightReport(
+    projectKey: string,
+    repositorySlug: string,
+    commitId: string,
+    key: string,
+    report: Record<string, any>
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => BuildsAndDeploymentsService.setACodeInsightsReport(projectKey, commitId, repositorySlug, key, report as any),
+      'Error setting code insights report'
+    );
+  }
+
+  /**
+   * Get a Code Insights report on a commit
+   */
+  async getInsightReport(projectKey: string, repositorySlug: string, commitId: string, key: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => BuildsAndDeploymentsService.getACodeInsightsReport(projectKey, commitId, repositorySlug, key),
+      'Error fetching code insights report'
+    );
+  }
+
+  /**
+   * Delete a Code Insights report (and its annotations) on a commit
+   */
+  async deleteInsightReport(projectKey: string, repositorySlug: string, commitId: string, key: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const result = await handleApiOperation(
+      () => BuildsAndDeploymentsService.deleteACodeInsightsReport(projectKey, commitId, repositorySlug, key),
+      'Error deleting code insights report'
+    );
+    if (result.success) {
+      return { ...result, data: { deleted: true, key } };
+    }
+    return result;
+  }
+
+  /**
+   * Add annotations to a Code Insights report (bulk)
+   * @param annotations Array of annotations; each: { externalId, path, line, message, severity (LOW/MEDIUM/HIGH), link?, type? }
+   */
+  async addInsightAnnotations(
+    projectKey: string,
+    repositorySlug: string,
+    commitId: string,
+    key: string,
+    annotations: Array<Record<string, any>>
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const result = await handleApiOperation(
+      () => BuildsAndDeploymentsService.addAnnotations(projectKey, commitId, repositorySlug, key, { annotations } as any),
+      'Error adding code insights annotations'
+    );
+    if (result.success) {
+      return { ...result, data: { added: annotations.length, key } };
+    }
+    return result;
+  }
+
+  /**
+   * Get annotations of a Code Insights report
+   */
+  async getInsightAnnotations(projectKey: string, repositorySlug: string, commitId: string, key: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => BuildsAndDeploymentsService.getAnnotations(projectKey, commitId, repositorySlug, key),
+      'Error fetching code insights annotations'
+    );
+  }
+
+  /**
+   * Delete annotations of a Code Insights report
+   * @param externalId Optional external id; when given, only that annotation is deleted, otherwise all
+   */
+  async deleteInsightAnnotations(
+    projectKey: string,
+    repositorySlug: string,
+    commitId: string,
+    key: string,
+    externalId?: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const result = await handleApiOperation(
+      () => BuildsAndDeploymentsService.deleteAnnotations(projectKey, commitId, repositorySlug, key, externalId),
+      'Error deleting code insights annotations'
+    );
+    if (result.success) {
+      return { ...result, data: { deleted: true, key, ...(externalId ? { externalId } : {}) } };
+    }
+    return result;
   }
 
   /**
@@ -882,6 +992,61 @@ export const bitbucketToolSchemas = {
     since: z.string().optional().describe("The commit ID (exclusively) to retrieve commits after"),
     until: z.string().optional().describe("The commit ID (inclusively) to retrieve commits before"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  setInsightReport: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    commitId: z.string().describe("The commit id (hash) the report is attached to"),
+    key: z.string().describe("A unique, namespaced key identifying the report (e.g. 'mycompany.eslint')"),
+    report: z.object({
+      title: z.string().describe("The report title"),
+      details: z.string().optional().describe("Detailed description"),
+      result: z.enum(['PASS', 'FAIL']).optional().describe("Overall report result"),
+      reporter: z.string().optional().describe("Name of the tool/reporter that produced the report"),
+      link: z.string().optional().describe("URL linking to the full report"),
+      logoUrl: z.string().optional().describe("URL of a logo to display"),
+      data: z.array(z.any()).optional().describe("Array of report data items ({ title, type, value })")
+    }).passthrough().describe("The Code Insights report payload")
+  },
+  getInsightReport: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    commitId: z.string().describe("The commit id (hash)"),
+    key: z.string().describe("The report key")
+  },
+  deleteInsightReport: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    commitId: z.string().describe("The commit id (hash)"),
+    key: z.string().describe("The report key")
+  },
+  addInsightAnnotations: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    commitId: z.string().describe("The commit id (hash)"),
+    key: z.string().describe("The report key the annotations belong to"),
+    annotations: z.array(z.object({
+      externalId: z.string().describe("Unique id of the annotation within the report"),
+      path: z.string().describe("File path the annotation refers to"),
+      line: z.number().describe("Line number the annotation refers to"),
+      message: z.string().describe("The annotation message"),
+      severity: z.enum(['LOW', 'MEDIUM', 'HIGH']).describe("Annotation severity"),
+      link: z.string().optional().describe("URL with more detail"),
+      type: z.enum(['VULNERABILITY', 'CODE_SMELL', 'BUG']).optional().describe("Annotation type")
+    }).passthrough()).describe("Array of annotations to add to the report")
+  },
+  getInsightAnnotations: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    commitId: z.string().describe("The commit id (hash)"),
+    key: z.string().describe("The report key")
+  },
+  deleteInsightAnnotations: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    commitId: z.string().describe("The commit id (hash)"),
+    key: z.string().describe("The report key"),
+    externalId: z.string().optional().describe("If given, delete only this annotation; otherwise delete all annotations of the report")
   },
   getPullRequestComments: {
     projectKey: z.string().describe("The project key"),

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -78,6 +78,66 @@ server.tool(
 );
 
 server.tool(
+  "bitbucket_setInsightReport",
+  "Create or replace a Code Insights report on a commit (e.g. linter/scanner results). The report 'key' must be unique and namespaced. Use bitbucket_addInsightAnnotations to attach per-line findings.",
+  bitbucketToolSchemas.setInsightReport,
+  async ({ projectKey, repositorySlug, commitId, key, report }) => {
+    const result = await bitbucketService.setInsightReport(projectKey, repositorySlug, commitId, key, report);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_getInsightReport",
+  "Get a Code Insights report on a commit by its key.",
+  bitbucketToolSchemas.getInsightReport,
+  async ({ projectKey, repositorySlug, commitId, key }) => {
+    const result = await bitbucketService.getInsightReport(projectKey, repositorySlug, commitId, key);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_deleteInsightReport",
+  "Delete a Code Insights report (and its annotations) on a commit.",
+  bitbucketToolSchemas.deleteInsightReport,
+  async ({ projectKey, repositorySlug, commitId, key }) => {
+    const result = await bitbucketService.deleteInsightReport(projectKey, repositorySlug, commitId, key);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_addInsightAnnotations",
+  "Add annotations (per-file/line findings) to a Code Insights report. The report must already exist (bitbucket_setInsightReport).",
+  bitbucketToolSchemas.addInsightAnnotations,
+  async ({ projectKey, repositorySlug, commitId, key, annotations }) => {
+    const result = await bitbucketService.addInsightAnnotations(projectKey, repositorySlug, commitId, key, annotations);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_getInsightAnnotations",
+  "Get the annotations of a Code Insights report on a commit.",
+  bitbucketToolSchemas.getInsightAnnotations,
+  async ({ projectKey, repositorySlug, commitId, key }) => {
+    const result = await bitbucketService.getInsightAnnotations(projectKey, repositorySlug, commitId, key);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_deleteInsightAnnotations",
+  "Delete annotations of a Code Insights report. Pass externalId to delete a single annotation, or omit it to delete all.",
+  bitbucketToolSchemas.deleteInsightAnnotations,
+  async ({ projectKey, repositorySlug, commitId, key, externalId }) => {
+    const result = await bitbucketService.deleteInsightAnnotations(projectKey, repositorySlug, commitId, key, externalId);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
   "bitbucket_getPullRequests",
   "Get pull requests for a Bitbucket repository",
   bitbucketToolSchemas.getPullRequests,


### PR DESCRIPTION
## Summary

Adds six Code Insights MCP tools — Track A. Lets an agent publish linter/scanner/CI analysis results onto a commit so they surface in the PR diff.

| Tool | Endpoint |
|---|---|
| `bitbucket_setInsightReport` | `PUT /rest/insights/.../commits/{id}/reports/{key}` |
| `bitbucket_getInsightReport` | `GET` same |
| `bitbucket_deleteInsightReport` | `DELETE` same |
| `bitbucket_addInsightAnnotations` | `POST .../reports/{key}/annotations` (bulk) |
| `bitbucket_getInsightAnnotations` | `GET .../reports/{key}/annotations` |
| `bitbucket_deleteInsightAnnotations` | `DELETE .../reports/{key}/annotations` (optional `externalId`) |

No client regeneration needed — uses the existing `BuildsAndDeploymentsService.{set,get,delete}ACodeInsightsReport` / `{add,get,delete}Annotations`.

## Testing

- Unit tests added for all six (call mapping, ack shapes, error path). Full bitbucket suite green (142 tests).
- Verified against a live Bitbucket Data Center instance: full lifecycle on a commit — set report (200) → get (200) → add annotation (204) → get annotations (count 1) → delete annotation (204) → delete report (204).