### PR TITLE
feat(bitbucket): add repository webhook tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { PullRequestsService, RepositoryService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,13 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  RepositoryService: {
+    findWebhooks1: jest.fn(),
+    getWebhook1: jest.fn(),
+    createWebhook1: jest.fn(),
+    updateWebhook1: jest.fn(),
+    deleteWebhook1: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -2471,6 +2478,121 @@ describe('BitbucketService', () => {
         'TEST', 'test-repo', undefined, undefined,
         'refs/heads/feature', 'refs/heads/main'
       );
+    });
+  });
+
+  describe('webhooks', () => {
+    it('should get webhooks with normalized keys', async () => {
+      const mockData = { values: [{ id: 1 }], isLastPage: true };
+      (RepositoryService.findWebhooks1 as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.getWebhooks('test', 'Test-Repo', 'repo:refs_changed', true);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(RepositoryService.findWebhooks1).toHaveBeenCalledWith(
+        'TEST', 'test-repo', 'repo:refs_changed', true
+      );
+    });
+
+    it('should handle errors when getting webhooks', async () => {
+      (RepositoryService.findWebhooks1 as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.getWebhooks('TEST', 'test-repo');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should get a single webhook and stringify the statistics flag', async () => {
+      const mockData = { id: 7, name: 'hook' };
+      (RepositoryService.getWebhook1 as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.getWebhook('test', 'Test-Repo', '7', true);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(RepositoryService.getWebhook1).toHaveBeenCalledWith('TEST', '7', 'test-repo', 'true');
+    });
+
+    it('should pass undefined statistics when omitted on getWebhook', async () => {
+      (RepositoryService.getWebhook1 as jest.Mock).mockResolvedValue({});
+
+      await bitbucketService.getWebhook('TEST', 'test-repo', '7');
+
+      expect(RepositoryService.getWebhook1).toHaveBeenCalledWith('TEST', '7', 'test-repo', undefined);
+    });
+
+    it('should create a webhook with a built request body', async () => {
+      const mockData = { id: 9 };
+      (RepositoryService.createWebhook1 as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.createWebhook(
+        'test', 'Test-Repo', 'my hook', 'https://example.com/hook',
+        ['repo:refs_changed', 'pr:opened'], true, 's3cret', false
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(RepositoryService.createWebhook1).toHaveBeenCalledWith('TEST', 'test-repo', {
+        name: 'my hook',
+        url: 'https://example.com/hook',
+        events: ['repo:refs_changed', 'pr:opened'],
+        active: true,
+        configuration: { secret: 's3cret' },
+        sslVerificationRequired: false
+      });
+    });
+
+    it('should omit optional fields from the webhook body when not provided', async () => {
+      (RepositoryService.createWebhook1 as jest.Mock).mockResolvedValue({ id: 1 });
+
+      await bitbucketService.createWebhook(
+        'TEST', 'test-repo', 'minimal', 'https://example.com/h', ['pr:merged']
+      );
+
+      expect(RepositoryService.createWebhook1).toHaveBeenCalledWith('TEST', 'test-repo', {
+        name: 'minimal',
+        url: 'https://example.com/h',
+        events: ['pr:merged']
+      });
+    });
+
+    it('should update a webhook', async () => {
+      const mockData = { id: 5 };
+      (RepositoryService.updateWebhook1 as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.updateWebhook(
+        'test', 'Test-Repo', '5', 'renamed', 'https://example.com/new', ['pr:declined'], false
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(RepositoryService.updateWebhook1).toHaveBeenCalledWith('TEST', '5', 'test-repo', {
+        name: 'renamed',
+        url: 'https://example.com/new',
+        events: ['pr:declined'],
+        active: false
+      });
+    });
+
+    it('should delete a webhook and return an ack', async () => {
+      (RepositoryService.deleteWebhook1 as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.deleteWebhook('test', 'Test-Repo', '5');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ deleted: true, webhookId: '5' });
+      expect(RepositoryService.deleteWebhook1).toHaveBeenCalledWith('TEST', '5', 'test-repo');
+    });
+
+    it('should preserve the error field when delete fails', async () => {
+      (RepositoryService.deleteWebhook1 as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.deleteWebhook('TEST', 'test-repo', '5');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
     });
   });
 });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -824,6 +824,144 @@ export class BitbucketService {
     return result;
   }
 
+  /**
+   * Find webhooks in a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param event Optional webhook event ID to filter for (e.g. 'repo:refs_changed')
+   * @param statistics Optional flag to include invocation statistics for each webhook
+   * @returns Promise with the page of webhooks
+   */
+  async getWebhooks(projectKey: string, repositorySlug: string, event?: string, statistics?: boolean) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.findWebhooks1(projectKey, repositorySlug, event, statistics),
+      'Error fetching webhooks'
+    );
+  }
+
+  /**
+   * Get a single webhook by ID
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param webhookId The ID of the webhook
+   * @param statistics Optional flag to include invocation statistics
+   * @returns Promise with the webhook
+   */
+  async getWebhook(projectKey: string, repositorySlug: string, webhookId: string, statistics?: boolean) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.getWebhook1(
+        projectKey,
+        webhookId,
+        repositorySlug,
+        statistics === undefined ? undefined : String(statistics)
+      ),
+      'Error fetching webhook'
+    );
+  }
+
+  /**
+   * Create a webhook for a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param name The webhook name
+   * @param url The endpoint URL the webhook will POST to
+   * @param events List of event IDs to subscribe to (e.g. ['repo:refs_changed', 'pr:opened'])
+   * @param active Optional flag controlling whether the webhook is enabled (default: true)
+   * @param secret Optional secret used to sign webhook payloads (HMAC)
+   * @param sslVerificationRequired Optional flag for SSL verification on the endpoint URL
+   * @returns Promise with the created webhook
+   */
+  async createWebhook(
+    projectKey: string,
+    repositorySlug: string,
+    name: string,
+    url: string,
+    events: string[],
+    active?: boolean,
+    secret?: string,
+    sslVerificationRequired?: boolean
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody = this.buildWebhookBody(name, url, events, active, secret, sslVerificationRequired);
+    return handleApiOperation(
+      () => RepositoryService.createWebhook1(projectKey, repositorySlug, requestBody),
+      'Error creating webhook'
+    );
+  }
+
+  /**
+   * Update an existing webhook (replaces its configuration)
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param webhookId The ID of the webhook to update
+   * @param name The webhook name
+   * @param url The endpoint URL the webhook will POST to
+   * @param events List of event IDs to subscribe to
+   * @param active Optional flag controlling whether the webhook is enabled
+   * @param secret Optional secret used to sign webhook payloads (HMAC)
+   * @param sslVerificationRequired Optional flag for SSL verification on the endpoint URL
+   * @returns Promise with the updated webhook
+   */
+  async updateWebhook(
+    projectKey: string,
+    repositorySlug: string,
+    webhookId: string,
+    name: string,
+    url: string,
+    events: string[],
+    active?: boolean,
+    secret?: string,
+    sslVerificationRequired?: boolean
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody = this.buildWebhookBody(name, url, events, active, secret, sslVerificationRequired);
+    return handleApiOperation(
+      () => RepositoryService.updateWebhook1(projectKey, webhookId, repositorySlug, requestBody),
+      'Error updating webhook'
+    );
+  }
+
+  /**
+   * Delete a webhook
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param webhookId The ID of the webhook to delete
+   * @returns Promise with a delete acknowledgement
+   */
+  async deleteWebhook(projectKey: string, repositorySlug: string, webhookId: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const result = await handleApiOperation(
+      () => RepositoryService.deleteWebhook1(projectKey, webhookId, repositorySlug),
+      'Error deleting webhook'
+    );
+    return { ...result, data: { deleted: true, webhookId } };
+  }
+
+  private buildWebhookBody(
+    name: string,
+    url: string,
+    events: string[],
+    active?: boolean,
+    secret?: string,
+    sslVerificationRequired?: boolean
+  ): any {
+    return {
+      name,
+      url,
+      events,
+      ...(active !== undefined ? { active } : {}),
+      ...(secret ? { configuration: { secret } } : {}),
+      ...(sslVerificationRequired !== undefined ? { sslVerificationRequired } : {}),
+    };
+  }
+
   async validateSetup(): Promise<void> {
     await __request(OpenAPI, {
       method: 'GET',
@@ -995,5 +1133,43 @@ export const bitbucketToolSchemas = {
   getInboxPullRequests: {
     start: z.number().optional().describe("Start number for the page (inclusive). If not passed, first page is assumed"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  getWebhooks: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    event: z.string().optional().describe("Optional webhook event ID to filter for (e.g. 'repo:refs_changed', 'pr:opened')"),
+    statistics: z.boolean().optional().describe("If true, include invocation statistics for each webhook")
+  },
+  getWebhook: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    webhookId: z.string().describe("The ID of the webhook"),
+    statistics: z.boolean().optional().describe("If true, include invocation statistics for the webhook")
+  },
+  createWebhook: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    name: z.string().describe("The webhook name"),
+    url: z.string().describe("The endpoint URL the webhook will POST to"),
+    events: z.array(z.string()).describe("List of event IDs to subscribe to (e.g. ['repo:refs_changed', 'pr:opened', 'pr:merged'])"),
+    active: z.boolean().optional().describe("Whether the webhook is enabled. Defaults to true on the server side."),
+    secret: z.string().optional().describe("Optional secret used to sign webhook payloads (HMAC)"),
+    sslVerificationRequired: z.boolean().optional().describe("Whether SSL verification is required for the endpoint URL")
+  },
+  updateWebhook: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    webhookId: z.string().describe("The ID of the webhook to update"),
+    name: z.string().describe("The webhook name"),
+    url: z.string().describe("The endpoint URL the webhook will POST to"),
+    events: z.array(z.string()).describe("List of event IDs to subscribe to. This replaces the existing event set."),
+    active: z.boolean().optional().describe("Whether the webhook is enabled"),
+    secret: z.string().optional().describe("Optional secret used to sign webhook payloads (HMAC)"),
+    sslVerificationRequired: z.boolean().optional().describe("Whether SSL verification is required for the endpoint URL")
+  },
+  deleteWebhook: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    webhookId: z.string().describe("The ID of the webhook to delete")
   }
 };

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -218,4 +218,54 @@ server.tool(
   }
 );
 
+server.tool(
+  "bitbucket_getWebhooks",
+  "List webhooks configured on a Bitbucket repository. Requires REPO_ADMIN permission. Optionally filter by event ID and include invocation statistics.",
+  bitbucketToolSchemas.getWebhooks,
+  async ({ projectKey, repositorySlug, event, statistics }) => {
+    const result = await bitbucketService.getWebhooks(projectKey, repositorySlug, event, statistics);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_getWebhook",
+  "Get a single Bitbucket repository webhook by its ID. Requires REPO_ADMIN permission.",
+  bitbucketToolSchemas.getWebhook,
+  async ({ projectKey, repositorySlug, webhookId, statistics }) => {
+    const result = await bitbucketService.getWebhook(projectKey, repositorySlug, webhookId, statistics);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_createWebhook",
+  "Create a webhook on a Bitbucket repository. Requires REPO_ADMIN permission. Provide the target URL and a list of event IDs to subscribe to (e.g. 'repo:refs_changed', 'pr:opened', 'pr:merged').",
+  bitbucketToolSchemas.createWebhook,
+  async ({ projectKey, repositorySlug, name, url, events, active, secret, sslVerificationRequired }) => {
+    const result = await bitbucketService.createWebhook(projectKey, repositorySlug, name, url, events, active, secret, sslVerificationRequired);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_updateWebhook",
+  "Update an existing Bitbucket repository webhook. Requires REPO_ADMIN permission. This replaces the webhook configuration, including its event set, so pass the full desired name/url/events.",
+  bitbucketToolSchemas.updateWebhook,
+  async ({ projectKey, repositorySlug, webhookId, name, url, events, active, secret, sslVerificationRequired }) => {
+    const result = await bitbucketService.updateWebhook(projectKey, repositorySlug, webhookId, name, url, events, active, secret, sslVerificationRequired);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_deleteWebhook",
+  "Delete a webhook from a Bitbucket repository by its ID. Requires REPO_ADMIN permission.",
+  bitbucketToolSchemas.deleteWebhook,
+  async ({ projectKey, repositorySlug, webhookId }) => {
+    const result = await bitbucketService.deleteWebhook(projectKey, repositorySlug, webhookId);
+    return formatToolResponse(result);
+  }
+);
+
 await connectServer(server);


### PR DESCRIPTION
## Summary

Adds CRUD tooling for **Bitbucket repository webhooks** (REPO_ADMIN scope). Five new MCP tools:

- `bitbucket_getWebhooks` — list webhooks for a repo; optional `event` filter and `statistics` flag
- `bitbucket_getWebhook` — fetch a single webhook by ID
- `bitbucket_createWebhook` — create a webhook (`url`, `events[]`, optional `active`, `secret`, `sslVerificationRequired`)
- `bitbucket_updateWebhook` — replace an existing webhook's configuration
- `bitbucket_deleteWebhook` — delete a webhook (compact ack response)

Backed by the generated `RepositoryService.findWebhooks1` / `getWebhook1` / `createWebhook1` / `updateWebhook1` / `deleteWebhook1`. No client regeneration required.

## Testing

- `npm run build` + `npm run test --workspace=@atlassian-dc-mcp/bitbucket` green (144 tests).
- Unit tests cover key normalization (projectKey upper / repositorySlug lower), request-body construction (optional `active`/`secret`/`ssl` omitted when not supplied), the `statistics` stringification on get, the delete ack, and error paths.
- Live-verified against a Bitbucket DC 9.x instance (full lifecycle on `TEST/demo`): create `201` → list `200` (hook present) → get `200` → update `200` (events/active changed) → delete `204` → re-get `404`. Throwaway hook cleaned up.