### PR TITLE
feat(bitbucket): add repository CRUD tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { ProjectService, PullRequestsService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,12 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  ProjectService: {
+    createRepository: jest.fn(),
+    updateRepository: jest.fn(),
+    forkRepository: jest.fn(),
+    deleteRepository: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -2471,6 +2477,114 @@ describe('BitbucketService', () => {
         'TEST', 'test-repo', undefined, undefined,
         'refs/heads/feature', 'refs/heads/main'
       );
+    });
+  });
+
+  describe('repository CRUD', () => {
+    it('should create a repository with default scm', async () => {
+      const mockData = { slug: 'new-repo' };
+      (ProjectService.createRepository as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.createRepository('test', 'New Repo');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(ProjectService.createRepository).toHaveBeenCalledWith('TEST', {
+        name: 'New Repo',
+        scmId: 'git'
+      });
+    });
+
+    it('should create a repository with a custom scm and default branch', async () => {
+      (ProjectService.createRepository as jest.Mock).mockResolvedValue({});
+
+      await bitbucketService.createRepository('TEST', 'Repo', 'hg', 'main');
+
+      expect(ProjectService.createRepository).toHaveBeenCalledWith('TEST', {
+        name: 'Repo',
+        scmId: 'hg',
+        defaultBranch: 'main'
+      });
+    });
+
+    it('should handle errors when creating a repository', async () => {
+      (ProjectService.createRepository as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.createRepository('TEST', 'Repo');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should update a repository with only the provided fields', async () => {
+      const mockData = { slug: 'renamed' };
+      (ProjectService.updateRepository as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.updateRepository(
+        'test', 'Test-Repo', 'Renamed', 'desc', 'main', 'dest'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(ProjectService.updateRepository).toHaveBeenCalledWith('TEST', 'test-repo', {
+        name: 'Renamed',
+        description: 'desc',
+        defaultBranch: 'main',
+        project: { key: 'DEST' }
+      });
+    });
+
+    it('should send an empty body when no update fields are provided', async () => {
+      (ProjectService.updateRepository as jest.Mock).mockResolvedValue({});
+
+      await bitbucketService.updateRepository('TEST', 'test-repo');
+
+      expect(ProjectService.updateRepository).toHaveBeenCalledWith('TEST', 'test-repo', {});
+    });
+
+    it('should fork a repository into a target project', async () => {
+      const mockData = { slug: 'fork' };
+      (ProjectService.forkRepository as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.forkRepository('test', 'Test-Repo', 'my-fork', 'dest');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(ProjectService.forkRepository).toHaveBeenCalledWith('TEST', 'test-repo', {
+        name: 'my-fork',
+        project: { key: 'DEST' }
+      });
+    });
+
+    it('should fork a repository with an empty body when no options provided', async () => {
+      (ProjectService.forkRepository as jest.Mock).mockResolvedValue({});
+
+      await bitbucketService.forkRepository('TEST', 'test-repo');
+
+      expect(ProjectService.forkRepository).toHaveBeenCalledWith('TEST', 'test-repo', {});
+    });
+
+    it('should delete a repository and return an ack', async () => {
+      (ProjectService.deleteRepository as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.deleteRepository('test', 'Test-Repo');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        scheduledForDeletion: true,
+        projectKey: 'TEST',
+        repositorySlug: 'test-repo'
+      });
+      expect(ProjectService.deleteRepository).toHaveBeenCalledWith('TEST', 'test-repo');
+    });
+
+    it('should preserve the error field when delete fails', async () => {
+      (ProjectService.deleteRepository as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.deleteRepository('TEST', 'test-repo');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
     });
   });
 });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -824,6 +824,104 @@ export class BitbucketService {
     return result;
   }
 
+  /**
+   * Create a new repository in a project
+   * @param projectKey The project key the repository will be created in
+   * @param name The repository name
+   * @param scmId The SCM type (defaults to 'git')
+   * @param defaultBranch Optional default branch for the new repository
+   * @returns Promise with the created repository
+   */
+  async createRepository(projectKey: string, name: string, scmId: string = 'git', defaultBranch?: string) {
+    projectKey = projectKey.toUpperCase();
+    const requestBody: any = {
+      name,
+      scmId,
+      ...(defaultBranch ? { defaultBranch } : {}),
+    };
+    return handleApiOperation(
+      () => ProjectService.createRepository(projectKey, requestBody),
+      'Error creating repository'
+    );
+  }
+
+  /**
+   * Update an existing repository (rename, change description, default branch, or move project)
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param name Optional new repository name
+   * @param description Optional new description
+   * @param defaultBranch Optional new default branch
+   * @param targetProjectKey Optional project key to move the repository into
+   * @returns Promise with the updated repository
+   */
+  async updateRepository(
+    projectKey: string,
+    repositorySlug: string,
+    name?: string,
+    description?: string,
+    defaultBranch?: string,
+    targetProjectKey?: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody: any = {
+      ...(name !== undefined ? { name } : {}),
+      ...(description !== undefined ? { description } : {}),
+      ...(defaultBranch !== undefined ? { defaultBranch } : {}),
+      ...(targetProjectKey ? { project: { key: targetProjectKey.toUpperCase() } } : {}),
+    };
+    return handleApiOperation(
+      () => ProjectService.updateRepository(projectKey, repositorySlug, requestBody),
+      'Error updating repository'
+    );
+  }
+
+  /**
+   * Fork an existing repository
+   * @param projectKey The project key of the origin repository
+   * @param repositorySlug The repository slug of the origin repository
+   * @param name Optional name for the fork (defaults to the origin name)
+   * @param targetProjectKey Optional target project key (defaults to the user's personal project)
+   * @param defaultBranch Optional default branch for the fork
+   * @returns Promise with the created fork
+   */
+  async forkRepository(
+    projectKey: string,
+    repositorySlug: string,
+    name?: string,
+    targetProjectKey?: string,
+    defaultBranch?: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody: any = {
+      ...(name ? { name } : {}),
+      ...(targetProjectKey ? { project: { key: targetProjectKey.toUpperCase() } } : {}),
+      ...(defaultBranch ? { defaultBranch } : {}),
+    };
+    return handleApiOperation(
+      () => ProjectService.forkRepository(projectKey, repositorySlug, requestBody),
+      'Error forking repository'
+    );
+  }
+
+  /**
+   * Schedule a repository for deletion
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @returns Promise with a deletion acknowledgement
+   */
+  async deleteRepository(projectKey: string, repositorySlug: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const result = await handleApiOperation(
+      () => ProjectService.deleteRepository(projectKey, repositorySlug),
+      'Error deleting repository'
+    );
+    return { ...result, data: { scheduledForDeletion: true, projectKey, repositorySlug } };
+  }
+
   async validateSetup(): Promise<void> {
     await __request(OpenAPI, {
       method: 'GET',
@@ -995,5 +1093,30 @@ export const bitbucketToolSchemas = {
   getInboxPullRequests: {
     start: z.number().optional().describe("Start number for the page (inclusive). If not passed, first page is assumed"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  createRepository: {
+    projectKey: z.string().describe("The project key the repository will be created in"),
+    name: z.string().describe("The repository name"),
+    scmId: z.string().optional().describe("The SCM type. Defaults to 'git'."),
+    defaultBranch: z.string().optional().describe("Optional default branch for the new repository (e.g. 'main')")
+  },
+  updateRepository: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    name: z.string().optional().describe("New repository name. Changing the name may change the slug."),
+    description: z.string().optional().describe("New repository description"),
+    defaultBranch: z.string().optional().describe("New default branch (e.g. 'main')"),
+    targetProjectKey: z.string().optional().describe("Project key to move the repository into")
+  },
+  forkRepository: {
+    projectKey: z.string().describe("The project key of the origin repository"),
+    repositorySlug: z.string().describe("The repository slug of the origin repository"),
+    name: z.string().optional().describe("Name for the fork. Defaults to the origin repository name."),
+    targetProjectKey: z.string().optional().describe("Target project key for the fork. Defaults to the user's personal project."),
+    defaultBranch: z.string().optional().describe("Default branch for the fork. Defaults to the origin's default branch.")
+  },
+  deleteRepository: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug")
   }
 };

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -218,4 +218,44 @@ server.tool(
   }
 );
 
+server.tool(
+  "bitbucket_createRepository",
+  "Create a new repository in a Bitbucket project. Requires REPO_CREATE permission on the project. SCM defaults to 'git'.",
+  bitbucketToolSchemas.createRepository,
+  async ({ projectKey, name, scmId, defaultBranch }) => {
+    const result = await bitbucketService.createRepository(projectKey, name, scmId, defaultBranch);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_updateRepository",
+  "Update a Bitbucket repository: rename it, change its description or default branch, or move it to another project. Requires REPO_ADMIN permission. Only the provided fields are changed.",
+  bitbucketToolSchemas.updateRepository,
+  async ({ projectKey, repositorySlug, name, description, defaultBranch, targetProjectKey }) => {
+    const result = await bitbucketService.updateRepository(projectKey, repositorySlug, name, description, defaultBranch, targetProjectKey);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_forkRepository",
+  "Fork an existing Bitbucket repository. Requires REPO_READ on the origin and PROJECT_ADMIN on the target project. Without a target project the fork goes to the user's personal project.",
+  bitbucketToolSchemas.forkRepository,
+  async ({ projectKey, repositorySlug, name, targetProjectKey, defaultBranch }) => {
+    const result = await bitbucketService.forkRepository(projectKey, repositorySlug, name, targetProjectKey, defaultBranch);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_deleteRepository",
+  "Schedule a Bitbucket repository for deletion. Requires REPO_ADMIN (or the configured delete policy) permission. This is irreversible — the repository and its contents are removed.",
+  bitbucketToolSchemas.deleteRepository,
+  async ({ projectKey, repositorySlug }) => {
+    const result = await bitbucketService.deleteRepository(projectKey, repositorySlug);
+    return formatToolResponse(result);
+  }
+);
+
 await connectServer(server);


### PR DESCRIPTION
## Summary

Adds repository lifecycle tooling. Four new MCP tools:

- `bitbucket_createRepository` — create a repo in a project (`scmId` defaults to `git`, optional `defaultBranch`)
- `bitbucket_updateRepository` — rename, change description/default branch, or move the repo to another project; only the supplied fields are sent
- `bitbucket_forkRepository` — fork a repo into a target project (or the user's personal project by default)
- `bitbucket_deleteRepository` — schedule a repo for deletion (compact ack)

Backed by the generated `ProjectService.createRepository` / `updateRepository` / `forkRepository` / `deleteRepository`. No client regeneration required.

## Testing

- `npm run build` + `npm run test --workspace=@atlassian-dc-mcp/bitbucket` green (144 tests).
- Unit tests cover key normalization (projectKey upper / repositorySlug lower / target project key upper), partial update bodies (empty body when nothing supplied), fork target mapping, the delete ack shape, and error paths.
- Live-verified against a Bitbucket DC 9.x instance (`TEST` project): create `201` → update `200` (description applied) → fork `201` (origin links back to the source) → delete fork `202` → delete origin `202`. Throwaway repos cleaned up.