### PR TITLE
feat(bitbucket): add project CRUD tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { ProjectService, PullRequestsService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,11 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  ProjectService: {
+    createProject: jest.fn(),
+    updateProject: jest.fn(),
+    deleteProject: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -2471,6 +2476,85 @@ describe('BitbucketService', () => {
         'TEST', 'test-repo', undefined, undefined,
         'refs/heads/feature', 'refs/heads/main'
       );
+    });
+  });
+
+  describe('project CRUD', () => {
+    it('should create a project', async () => {
+      const mockData = { key: 'PROJ' };
+      (ProjectService.createProject as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.createProject('proj', 'My Project', 'desc');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(ProjectService.createProject).toHaveBeenCalledWith({
+        key: 'PROJ',
+        name: 'My Project',
+        description: 'desc'
+      });
+    });
+
+    it('should omit description when not provided on create', async () => {
+      (ProjectService.createProject as jest.Mock).mockResolvedValue({});
+
+      await bitbucketService.createProject('PROJ', 'My Project');
+
+      expect(ProjectService.createProject).toHaveBeenCalledWith({
+        key: 'PROJ',
+        name: 'My Project'
+      });
+    });
+
+    it('should handle errors when creating a project', async () => {
+      (ProjectService.createProject as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.createProject('PROJ', 'My Project');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should update a project with only the provided fields', async () => {
+      const mockData = { key: 'PROJ' };
+      (ProjectService.updateProject as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.updateProject('proj', 'Renamed', 'new desc');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(ProjectService.updateProject).toHaveBeenCalledWith('PROJ', {
+        key: 'PROJ',
+        name: 'Renamed',
+        description: 'new desc'
+      });
+    });
+
+    it('should update a project sending only the key when nothing else provided', async () => {
+      (ProjectService.updateProject as jest.Mock).mockResolvedValue({});
+
+      await bitbucketService.updateProject('PROJ');
+
+      expect(ProjectService.updateProject).toHaveBeenCalledWith('PROJ', { key: 'PROJ' });
+    });
+
+    it('should delete a project and return an ack', async () => {
+      (ProjectService.deleteProject as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.deleteProject('proj');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ deleted: true, key: 'PROJ' });
+      expect(ProjectService.deleteProject).toHaveBeenCalledWith('PROJ');
+    });
+
+    it('should preserve the error field when delete fails', async () => {
+      (ProjectService.deleteProject as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.deleteProject('PROJ');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
     });
   });
 });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -824,6 +824,60 @@ export class BitbucketService {
     return result;
   }
 
+  /**
+   * Create a new project
+   * @param key The project key
+   * @param name The project name
+   * @param description Optional project description
+   * @returns Promise with the created project
+   */
+  async createProject(key: string, name: string, description?: string) {
+    key = key.toUpperCase();
+    const requestBody: any = {
+      key,
+      name,
+      ...(description !== undefined ? { description } : {}),
+    };
+    return handleApiOperation(
+      () => ProjectService.createProject(requestBody),
+      'Error creating project'
+    );
+  }
+
+  /**
+   * Update an existing project (the project key is never changed)
+   * @param key The project key
+   * @param name Optional new project name
+   * @param description Optional new description
+   * @returns Promise with the updated project
+   */
+  async updateProject(key: string, name?: string, description?: string) {
+    key = key.toUpperCase();
+    const requestBody: any = {
+      key,
+      ...(name !== undefined ? { name } : {}),
+      ...(description !== undefined ? { description } : {}),
+    };
+    return handleApiOperation(
+      () => ProjectService.updateProject(key, requestBody),
+      'Error updating project'
+    );
+  }
+
+  /**
+   * Delete a project (must contain no repositories)
+   * @param key The project key
+   * @returns Promise with a deletion acknowledgement
+   */
+  async deleteProject(key: string) {
+    key = key.toUpperCase();
+    const result = await handleApiOperation(
+      () => ProjectService.deleteProject(key),
+      'Error deleting project'
+    );
+    return { ...result, data: { deleted: true, key } };
+  }
+
   async validateSetup(): Promise<void> {
     await __request(OpenAPI, {
       method: 'GET',
@@ -995,5 +1049,18 @@ export const bitbucketToolSchemas = {
   getInboxPullRequests: {
     start: z.number().optional().describe("Start number for the page (inclusive). If not passed, first page is assumed"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  createProject: {
+    key: z.string().describe("The project key (e.g. 'PROJ'). Used in URLs and must be unique."),
+    name: z.string().describe("The project name"),
+    description: z.string().optional().describe("Optional project description")
+  },
+  updateProject: {
+    key: z.string().describe("The project key. The key itself is never changed by this operation."),
+    name: z.string().optional().describe("New project name"),
+    description: z.string().optional().describe("New project description")
+  },
+  deleteProject: {
+    key: z.string().describe("The project key. The project must contain no repositories.")
   }
 };

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -218,4 +218,34 @@ server.tool(
   }
 );
 
+server.tool(
+  "bitbucket_createProject",
+  "Create a new Bitbucket project. Requires PROJECT_CREATE permission. The key must be unique.",
+  bitbucketToolSchemas.createProject,
+  async ({ key, name, description }) => {
+    const result = await bitbucketService.createProject(key, name, description);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_updateProject",
+  "Update an existing Bitbucket project's name or description. Requires PROJECT_ADMIN permission. The project key is never changed. Only the provided fields are updated.",
+  bitbucketToolSchemas.updateProject,
+  async ({ key, name, description }) => {
+    const result = await bitbucketService.updateProject(key, name, description);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_deleteProject",
+  "Delete a Bitbucket project. Requires PROJECT_ADMIN permission. The project must contain no repositories or the call fails with a conflict.",
+  bitbucketToolSchemas.deleteProject,
+  async ({ key }) => {
+    const result = await bitbucketService.deleteProject(key);
+    return formatToolResponse(result);
+  }
+);
+
 await connectServer(server);


### PR DESCRIPTION
## Summary

Adds project lifecycle tooling. Three new MCP tools:

- `bitbucket_createProject` — create a project (`key`, `name`, optional `description`); requires PROJECT_CREATE
- `bitbucket_updateProject` — rename or change description; the project key is never changed; requires PROJECT_ADMIN
- `bitbucket_deleteProject` — delete a project (must contain no repositories); compact ack; requires PROJECT_ADMIN

Backed by the generated `ProjectService.createProject` / `updateProject` / `deleteProject`. No client regeneration required.

## Testing

- `npm run build` + `npm run test --workspace=@atlassian-dc-mcp/bitbucket` green (142 tests).
- Unit tests cover key normalization (key upper-cased), partial update bodies (only the key sent when nothing else supplied), the delete ack shape, and error paths.
- Live-verified against a Bitbucket DC 9.x instance: create `201` → update `200` (rename + description applied) → get `200` (reflects rename) → delete `204` → re-get `404`. Throwaway project cleaned up.