### PR TITLE
feat(bitbucket): add pull request operation tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -23,7 +23,11 @@ jest.mock('../bitbucket-client/index.js', () => ({
     updateStatus: jest.fn(),
     getPage: jest.fn(),
     getReviewers: jest.fn(),
-    get3: jest.fn()
+    get3: jest.fn(),
+    deleteComment2: jest.fn(),
+    applySuggestion: jest.fn(),
+    watch1: jest.fn(),
+    unwatch1: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -2471,6 +2475,85 @@ describe('BitbucketService', () => {
         'TEST', 'test-repo', undefined, undefined,
         'refs/heads/feature', 'refs/heads/main'
       );
+    });
+  });
+
+  describe('pull request operations', () => {
+    it('should delete a pull request comment and return an ack', async () => {
+      (PullRequestsService.deleteComment2 as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.deletePullRequestComment('test', 'Test-Repo', '123', '99', 4);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ deleted: true, commentId: '99' });
+      expect(PullRequestsService.deleteComment2).toHaveBeenCalledWith('TEST', '99', '123', 'test-repo', '4');
+    });
+
+    it('should preserve the error field when comment delete fails', async () => {
+      (PullRequestsService.deleteComment2 as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.deletePullRequestComment('TEST', 'test-repo', '123', '99', 4);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should apply a suggestion with a full body', async () => {
+      (PullRequestsService.applySuggestion as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.applyPullRequestSuggestion(
+        'test', 'Test-Repo', '123', '99', 2, 5, 'apply fix', 1
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ applied: true, commentId: '99' });
+      expect(PullRequestsService.applySuggestion).toHaveBeenCalledWith('TEST', '99', '123', 'test-repo', {
+        commentVersion: 2,
+        pullRequestVersion: 5,
+        message: 'apply fix',
+        suggestionIndex: 1
+      });
+    });
+
+    it('should apply a suggestion omitting the optional suggestion index', async () => {
+      (PullRequestsService.applySuggestion as jest.Mock).mockResolvedValue(undefined);
+
+      await bitbucketService.applyPullRequestSuggestion('TEST', 'test-repo', '123', '99', 2, 5, 'apply fix');
+
+      expect(PullRequestsService.applySuggestion).toHaveBeenCalledWith('TEST', '99', '123', 'test-repo', {
+        commentVersion: 2,
+        pullRequestVersion: 5,
+        message: 'apply fix'
+      });
+    });
+
+    it('should watch a pull request and return an ack', async () => {
+      (PullRequestsService.watch1 as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.watchPullRequest('test', 'Test-Repo', '123');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ watching: true, pullRequestId: '123' });
+      expect(PullRequestsService.watch1).toHaveBeenCalledWith('TEST', '123', 'test-repo');
+    });
+
+    it('should unwatch a pull request and return an ack', async () => {
+      (PullRequestsService.unwatch1 as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.unwatchPullRequest('test', 'Test-Repo', '123');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ watching: false, pullRequestId: '123' });
+      expect(PullRequestsService.unwatch1).toHaveBeenCalledWith('TEST', '123', 'test-repo');
+    });
+
+    it('should preserve the error field when watch fails', async () => {
+      (PullRequestsService.watch1 as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.watchPullRequest('TEST', 'test-repo', '123');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
     });
   });
 });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -824,6 +824,104 @@ export class BitbucketService {
     return result;
   }
 
+  /**
+   * Delete a pull request comment
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param pullRequestId The pull request ID
+   * @param commentId The ID of the comment to delete
+   * @param version The current version of the comment (optimistic locking)
+   * @returns Promise with a delete acknowledgement
+   */
+  async deletePullRequestComment(
+    projectKey: string,
+    repositorySlug: string,
+    pullRequestId: string,
+    commentId: string,
+    version: number
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const result = await handleApiOperation(
+      () => PullRequestsService.deleteComment2(projectKey, commentId, pullRequestId, repositorySlug, String(version)),
+      'Error deleting pull request comment'
+    );
+    return { ...result, data: { deleted: true, commentId } };
+  }
+
+  /**
+   * Apply a code suggestion contained in a pull request comment to the source branch
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param pullRequestId The pull request ID
+   * @param commentId The ID of the comment that contains the suggestion
+   * @param commentVersion The current version of the comment
+   * @param pullRequestVersion The current version of the pull request
+   * @param commitMessage Commit message for the commit that applies the suggestion (required by the server)
+   * @param suggestionIndex Optional index of the suggestion within the comment (defaults to the first)
+   * @returns Promise with an apply acknowledgement
+   */
+  async applyPullRequestSuggestion(
+    projectKey: string,
+    repositorySlug: string,
+    pullRequestId: string,
+    commentId: string,
+    commentVersion: number,
+    pullRequestVersion: number,
+    commitMessage: string,
+    suggestionIndex?: number
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    // The apply-suggestion endpoint reads the commit message from `message` (not `commitMessage`
+    // as the generated model suggests) and rejects an empty value.
+    const requestBody: any = {
+      commentVersion,
+      pullRequestVersion,
+      message: commitMessage,
+      ...(suggestionIndex !== undefined ? { suggestionIndex } : {}),
+    };
+    const result = await handleApiOperation(
+      () => PullRequestsService.applySuggestion(projectKey, commentId, pullRequestId, repositorySlug, requestBody),
+      'Error applying pull request suggestion'
+    );
+    return { ...result, data: { applied: true, commentId } };
+  }
+
+  /**
+   * Start watching a pull request (subscribe the authenticated user to notifications)
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param pullRequestId The pull request ID
+   * @returns Promise with a watch acknowledgement
+   */
+  async watchPullRequest(projectKey: string, repositorySlug: string, pullRequestId: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const result = await handleApiOperation(
+      () => PullRequestsService.watch1(projectKey, pullRequestId, repositorySlug),
+      'Error watching pull request'
+    );
+    return { ...result, data: { watching: true, pullRequestId } };
+  }
+
+  /**
+   * Stop watching a pull request (unsubscribe the authenticated user)
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param pullRequestId The pull request ID
+   * @returns Promise with an unwatch acknowledgement
+   */
+  async unwatchPullRequest(projectKey: string, repositorySlug: string, pullRequestId: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const result = await handleApiOperation(
+      () => PullRequestsService.unwatch1(projectKey, pullRequestId, repositorySlug),
+      'Error unwatching pull request'
+    );
+    return { ...result, data: { watching: false, pullRequestId } };
+  }
+
   async validateSetup(): Promise<void> {
     await __request(OpenAPI, {
       method: 'GET',
@@ -995,5 +1093,32 @@ export const bitbucketToolSchemas = {
   getInboxPullRequests: {
     start: z.number().optional().describe("Start number for the page (inclusive). If not passed, first page is assumed"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  deletePullRequestComment: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID"),
+    commentId: z.string().describe("The ID of the comment to delete"),
+    version: z.number().describe("The current version of the comment, required for optimistic locking. A comment with replies cannot be deleted.")
+  },
+  applyPullRequestSuggestion: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID"),
+    commentId: z.string().describe("The ID of the comment that contains the code suggestion"),
+    commentVersion: z.number().describe("The current version of the comment containing the suggestion"),
+    pullRequestVersion: z.number().describe("The current version of the pull request"),
+    commitMessage: z.string().describe("Commit message for the commit that applies the suggestion. Required and must be non-empty."),
+    suggestionIndex: z.number().optional().describe("Index of the suggestion within the comment when it contains several. Defaults to the first suggestion.")
+  },
+  watchPullRequest: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID")
+  },
+  unwatchPullRequest: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID")
   }
 };

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -218,4 +218,44 @@ server.tool(
   }
 );
 
+server.tool(
+  "bitbucket_deletePullRequestComment",
+  "Delete a comment from a Bitbucket pull request. Requires the current comment 'version' for optimistic locking. A comment that has replies cannot be deleted.",
+  bitbucketToolSchemas.deletePullRequestComment,
+  async ({ projectKey, repositorySlug, pullRequestId, commentId, version }) => {
+    const result = await bitbucketService.deletePullRequestComment(projectKey, repositorySlug, pullRequestId, commentId, version);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_applyPullRequestSuggestion",
+  "Apply a code suggestion contained in a pull request comment directly to the source branch, creating a commit. Requires the current comment version and pull request version. Equivalent to the 'Apply suggestion' button in the Bitbucket UI.",
+  bitbucketToolSchemas.applyPullRequestSuggestion,
+  async ({ projectKey, repositorySlug, pullRequestId, commentId, commentVersion, pullRequestVersion, commitMessage, suggestionIndex }) => {
+    const result = await bitbucketService.applyPullRequestSuggestion(projectKey, repositorySlug, pullRequestId, commentId, commentVersion, pullRequestVersion, commitMessage, suggestionIndex);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_watchPullRequest",
+  "Start watching a pull request, subscribing the authenticated user to its notifications.",
+  bitbucketToolSchemas.watchPullRequest,
+  async ({ projectKey, repositorySlug, pullRequestId }) => {
+    const result = await bitbucketService.watchPullRequest(projectKey, repositorySlug, pullRequestId);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_unwatchPullRequest",
+  "Stop watching a pull request, unsubscribing the authenticated user from its notifications.",
+  bitbucketToolSchemas.unwatchPullRequest,
+  async ({ projectKey, repositorySlug, pullRequestId }) => {
+    const result = await bitbucketService.unwatchPullRequest(projectKey, repositorySlug, pullRequestId);
+    return formatToolResponse(result);
+  }
+);
+
 await connectServer(server);


### PR DESCRIPTION
## Summary

Adds PR-level operation tooling. Four new MCP tools:

- `bitbucket_deletePullRequestComment` — delete a PR comment (requires the current comment `version`; a comment with replies cannot be deleted)
- `bitbucket_applyPullRequestSuggestion` — apply a code suggestion from a comment directly to the source branch, creating a commit (requires the comment version + PR version + a commit message)
- `bitbucket_watchPullRequest` / `bitbucket_unwatchPullRequest` — (un)subscribe the authenticated user to a PR's notifications

Backed by the generated `PullRequestsService.deleteComment2` / `applySuggestion` / `watch1` / `unwatch1`. No client regeneration required.

### Note on apply-suggestion

The apply-suggestion endpoint reads the commit message from a field named **`message`**, not `commitMessage` as the generated `RestApplySuggestionRequest` model declares, and rejects an empty value. The tool therefore maps its `commitMessage` argument to `message` and makes it required. This was confirmed live: sending `commitMessage` returned `400 'message' cannot be null or empty`, while `message` returned `204`.

## Testing

- `npm run build` + `npm run test --workspace=@atlassian-dc-mcp/bitbucket` green (142 tests).
- Unit tests cover key normalization, request-body construction (including the `message` mapping and optional `suggestionIndex`), the ack shapes, and error paths.
- Live-verified against a Bitbucket DC 9.x instance on a throwaway PR: watch `204` → unwatch `204` → post comment `201` → delete comment `204` → post inline suggestion `201` → apply suggestion `204`. The PR and temp branch were cleaned up afterward.