### PR TITLE
feat(bitbucket): add default reviewer condition tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -23,7 +23,11 @@ jest.mock('../bitbucket-client/index.js', () => ({
     updateStatus: jest.fn(),
     getPage: jest.fn(),
     getReviewers: jest.fn(),
-    get3: jest.fn()
+    get3: jest.fn(),
+    getPullRequestConditions1: jest.fn(),
+    createPullRequestCondition1: jest.fn(),
+    updatePullRequestCondition1: jest.fn(),
+    deletePullRequestCondition1: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -2471,6 +2475,99 @@ describe('BitbucketService', () => {
         'TEST', 'test-repo', undefined, undefined,
         'refs/heads/feature', 'refs/heads/main'
       );
+    });
+  });
+
+  describe('default reviewer conditions', () => {
+    it('should get default reviewer conditions with normalized keys', async () => {
+      const mockData = [{ id: 1 }];
+      (PullRequestsService.getPullRequestConditions1 as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.getDefaultReviewerConditions('test', 'Test-Repo');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(PullRequestsService.getPullRequestConditions1).toHaveBeenCalledWith('TEST', 'test-repo');
+    });
+
+    it('should create a condition mapping reviewer ids and matchers', async () => {
+      const mockData = { id: 1 };
+      (PullRequestsService.createPullRequestCondition1 as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.createDefaultReviewerCondition(
+        'test', 'Test-Repo', 'ANY_REF', 'ANY_REF', 'BRANCH', 'refs/heads/main', [52], 1, undefined, 'main'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(PullRequestsService.createPullRequestCondition1).toHaveBeenCalledWith('TEST', 'test-repo', {
+        reviewers: [{ id: 52 }],
+        sourceMatcher: { id: 'ANY_REF', displayId: 'ANY_REF', type: { id: 'ANY_REF' } },
+        targetMatcher: { id: 'refs/heads/main', displayId: 'main', type: { id: 'BRANCH' } },
+        requiredApprovals: 1
+      });
+    });
+
+    it('should omit requiredApprovals when not provided', async () => {
+      (PullRequestsService.createPullRequestCondition1 as jest.Mock).mockResolvedValue({});
+
+      await bitbucketService.createDefaultReviewerCondition(
+        'TEST', 'test-repo', 'ANY_REF', 'ANY_REF', 'ANY_REF', 'ANY_REF', [52]
+      );
+
+      expect(PullRequestsService.createPullRequestCondition1).toHaveBeenCalledWith('TEST', 'test-repo', {
+        reviewers: [{ id: 52 }],
+        sourceMatcher: { id: 'ANY_REF', displayId: 'ANY_REF', type: { id: 'ANY_REF' } },
+        targetMatcher: { id: 'ANY_REF', displayId: 'ANY_REF', type: { id: 'ANY_REF' } }
+      });
+    });
+
+    it('should handle errors when creating a condition', async () => {
+      (PullRequestsService.createPullRequestCondition1 as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.createDefaultReviewerCondition(
+        'TEST', 'test-repo', 'ANY_REF', 'ANY_REF', 'ANY_REF', 'ANY_REF', [52]
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should update a condition passing the id as a string', async () => {
+      const mockData = { id: 1, requiredApprovals: 2 };
+      (PullRequestsService.updatePullRequestCondition1 as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.updateDefaultReviewerCondition(
+        'test', 'Test-Repo', '1', 'ANY_REF', 'ANY_REF', 'BRANCH', 'refs/heads/main', [52], 2, undefined, 'main'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(PullRequestsService.updatePullRequestCondition1).toHaveBeenCalledWith('TEST', '1', 'test-repo', {
+        reviewers: [{ id: 52 }],
+        sourceMatcher: { id: 'ANY_REF', displayId: 'ANY_REF', type: { id: 'ANY_REF' } },
+        targetMatcher: { id: 'refs/heads/main', displayId: 'main', type: { id: 'BRANCH' } },
+        requiredApprovals: 2
+      });
+    });
+
+    it('should delete a condition coercing the id to a number and return an ack', async () => {
+      (PullRequestsService.deletePullRequestCondition1 as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.deleteDefaultReviewerCondition('test', 'Test-Repo', '1');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ deleted: true, id: '1' });
+      expect(PullRequestsService.deletePullRequestCondition1).toHaveBeenCalledWith('TEST', 1, 'test-repo');
+    });
+
+    it('should preserve the error field when delete fails', async () => {
+      (PullRequestsService.deletePullRequestCondition1 as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.deleteDefaultReviewerCondition('TEST', 'test-repo', '1');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
     });
   });
 });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -824,6 +824,142 @@ export class BitbucketService {
     return result;
   }
 
+  /**
+   * Get the default reviewer conditions configured for a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @returns Promise with the list of default reviewer conditions
+   */
+  async getDefaultReviewerConditions(projectKey: string, repositorySlug: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => PullRequestsService.getPullRequestConditions1(projectKey, repositorySlug),
+      'Error fetching default reviewer conditions'
+    );
+  }
+
+  /**
+   * Create a default reviewer condition for a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param sourceMatcherType Matcher type for the source ref (ANY_REF, BRANCH, PATTERN, MODEL_CATEGORY, MODEL_BRANCH)
+   * @param sourceMatcherValue Matcher value for the source ref (e.g. 'ANY_REF', 'refs/heads/main', a pattern, or a model id)
+   * @param targetMatcherType Matcher type for the target ref
+   * @param targetMatcherValue Matcher value for the target ref
+   * @param reviewerIds Numeric user IDs of the default reviewers
+   * @param requiredApprovals Optional number of required approvals
+   * @param sourceMatcherDisplayId Optional display value for the source matcher (defaults to the value)
+   * @param targetMatcherDisplayId Optional display value for the target matcher (defaults to the value)
+   * @returns Promise with the created condition
+   */
+  async createDefaultReviewerCondition(
+    projectKey: string,
+    repositorySlug: string,
+    sourceMatcherType: string,
+    sourceMatcherValue: string,
+    targetMatcherType: string,
+    targetMatcherValue: string,
+    reviewerIds: number[],
+    requiredApprovals?: number,
+    sourceMatcherDisplayId?: string,
+    targetMatcherDisplayId?: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody = this.buildDefaultReviewerBody(
+      sourceMatcherType, sourceMatcherValue, targetMatcherType, targetMatcherValue,
+      reviewerIds, requiredApprovals, sourceMatcherDisplayId, targetMatcherDisplayId
+    );
+    return handleApiOperation(
+      () => PullRequestsService.createPullRequestCondition1(projectKey, repositorySlug, requestBody),
+      'Error creating default reviewer condition'
+    );
+  }
+
+  /**
+   * Update an existing default reviewer condition (replaces the condition)
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param id The ID of the condition to update
+   * @param sourceMatcherType Matcher type for the source ref
+   * @param sourceMatcherValue Matcher value for the source ref
+   * @param targetMatcherType Matcher type for the target ref
+   * @param targetMatcherValue Matcher value for the target ref
+   * @param reviewerIds Numeric user IDs of the default reviewers
+   * @param requiredApprovals Optional number of required approvals
+   * @param sourceMatcherDisplayId Optional display value for the source matcher
+   * @param targetMatcherDisplayId Optional display value for the target matcher
+   * @returns Promise with the updated condition
+   */
+  async updateDefaultReviewerCondition(
+    projectKey: string,
+    repositorySlug: string,
+    id: string,
+    sourceMatcherType: string,
+    sourceMatcherValue: string,
+    targetMatcherType: string,
+    targetMatcherValue: string,
+    reviewerIds: number[],
+    requiredApprovals?: number,
+    sourceMatcherDisplayId?: string,
+    targetMatcherDisplayId?: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody = this.buildDefaultReviewerBody(
+      sourceMatcherType, sourceMatcherValue, targetMatcherType, targetMatcherValue,
+      reviewerIds, requiredApprovals, sourceMatcherDisplayId, targetMatcherDisplayId
+    );
+    return handleApiOperation(
+      () => PullRequestsService.updatePullRequestCondition1(projectKey, id, repositorySlug, requestBody),
+      'Error updating default reviewer condition'
+    );
+  }
+
+  /**
+   * Delete a default reviewer condition
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param id The ID of the condition to delete
+   * @returns Promise with a delete acknowledgement
+   */
+  async deleteDefaultReviewerCondition(projectKey: string, repositorySlug: string, id: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const result = await handleApiOperation(
+      () => PullRequestsService.deletePullRequestCondition1(projectKey, Number(id), repositorySlug),
+      'Error deleting default reviewer condition'
+    );
+    return { ...result, data: { deleted: true, id } };
+  }
+
+  private buildDefaultReviewerBody(
+    sourceMatcherType: string,
+    sourceMatcherValue: string,
+    targetMatcherType: string,
+    targetMatcherValue: string,
+    reviewerIds: number[],
+    requiredApprovals?: number,
+    sourceMatcherDisplayId?: string,
+    targetMatcherDisplayId?: string
+  ): any {
+    return {
+      reviewers: reviewerIds.map(id => ({ id })),
+      sourceMatcher: {
+        id: sourceMatcherValue,
+        displayId: sourceMatcherDisplayId ?? sourceMatcherValue,
+        type: { id: sourceMatcherType },
+      },
+      targetMatcher: {
+        id: targetMatcherValue,
+        displayId: targetMatcherDisplayId ?? targetMatcherValue,
+        type: { id: targetMatcherType },
+      },
+      ...(requiredApprovals !== undefined ? { requiredApprovals } : {}),
+    };
+  }
+
   async validateSetup(): Promise<void> {
     await __request(OpenAPI, {
       method: 'GET',
@@ -995,5 +1131,39 @@ export const bitbucketToolSchemas = {
   getInboxPullRequests: {
     start: z.number().optional().describe("Start number for the page (inclusive). If not passed, first page is assumed"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  getDefaultReviewerConditions: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug")
+  },
+  createDefaultReviewerCondition: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    sourceMatcherType: z.enum(['ANY_REF', 'BRANCH', 'PATTERN', 'MODEL_CATEGORY', 'MODEL_BRANCH']).describe("Matcher type for the source ref"),
+    sourceMatcherValue: z.string().describe("Matcher value for the source ref. For ANY_REF use 'ANY_REF'; for BRANCH use a ref id like 'refs/heads/main'; for PATTERN use the pattern; for MODEL_* use the model id."),
+    targetMatcherType: z.enum(['ANY_REF', 'BRANCH', 'PATTERN', 'MODEL_CATEGORY', 'MODEL_BRANCH']).describe("Matcher type for the target ref"),
+    targetMatcherValue: z.string().describe("Matcher value for the target ref (see sourceMatcherValue)"),
+    reviewerIds: z.array(z.number()).describe("Numeric user IDs of the default reviewers. Resolve a username to its numeric id via bitbucket_getUser."),
+    requiredApprovals: z.number().optional().describe("Number of approvals required from the default reviewers"),
+    sourceMatcherDisplayId: z.string().optional().describe("Display value for the source matcher (defaults to the matcher value, e.g. 'main' for 'refs/heads/main')"),
+    targetMatcherDisplayId: z.string().optional().describe("Display value for the target matcher (defaults to the matcher value)")
+  },
+  updateDefaultReviewerCondition: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    id: z.string().describe("The ID of the condition to update"),
+    sourceMatcherType: z.enum(['ANY_REF', 'BRANCH', 'PATTERN', 'MODEL_CATEGORY', 'MODEL_BRANCH']).describe("Matcher type for the source ref"),
+    sourceMatcherValue: z.string().describe("Matcher value for the source ref"),
+    targetMatcherType: z.enum(['ANY_REF', 'BRANCH', 'PATTERN', 'MODEL_CATEGORY', 'MODEL_BRANCH']).describe("Matcher type for the target ref"),
+    targetMatcherValue: z.string().describe("Matcher value for the target ref"),
+    reviewerIds: z.array(z.number()).describe("Numeric user IDs of the default reviewers. The update replaces the full condition, so pass the complete desired set."),
+    requiredApprovals: z.number().optional().describe("Number of approvals required from the default reviewers"),
+    sourceMatcherDisplayId: z.string().optional().describe("Display value for the source matcher (defaults to the matcher value)"),
+    targetMatcherDisplayId: z.string().optional().describe("Display value for the target matcher (defaults to the matcher value)")
+  },
+  deleteDefaultReviewerCondition: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    id: z.string().describe("The ID of the condition to delete")
   }
 };

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -218,4 +218,44 @@ server.tool(
   }
 );
 
+server.tool(
+  "bitbucket_getDefaultReviewerConditions",
+  "List the default reviewer conditions configured for a Bitbucket repository. Each condition maps a source/target ref matcher to a set of default reviewers and a required-approvals count.",
+  bitbucketToolSchemas.getDefaultReviewerConditions,
+  async ({ projectKey, repositorySlug }) => {
+    const result = await bitbucketService.getDefaultReviewerConditions(projectKey, repositorySlug);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_createDefaultReviewerCondition",
+  "Create a default reviewer condition on a Bitbucket repository. Matchers are specified by type (ANY_REF, BRANCH, PATTERN, MODEL_CATEGORY, MODEL_BRANCH) and value. Reviewers are given as numeric user IDs (resolve usernames via bitbucket_getUser).",
+  bitbucketToolSchemas.createDefaultReviewerCondition,
+  async ({ projectKey, repositorySlug, sourceMatcherType, sourceMatcherValue, targetMatcherType, targetMatcherValue, reviewerIds, requiredApprovals, sourceMatcherDisplayId, targetMatcherDisplayId }) => {
+    const result = await bitbucketService.createDefaultReviewerCondition(projectKey, repositorySlug, sourceMatcherType, sourceMatcherValue, targetMatcherType, targetMatcherValue, reviewerIds, requiredApprovals, sourceMatcherDisplayId, targetMatcherDisplayId);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_updateDefaultReviewerCondition",
+  "Update a default reviewer condition on a Bitbucket repository. This replaces the whole condition, so provide the complete desired matchers and reviewer set.",
+  bitbucketToolSchemas.updateDefaultReviewerCondition,
+  async ({ projectKey, repositorySlug, id, sourceMatcherType, sourceMatcherValue, targetMatcherType, targetMatcherValue, reviewerIds, requiredApprovals, sourceMatcherDisplayId, targetMatcherDisplayId }) => {
+    const result = await bitbucketService.updateDefaultReviewerCondition(projectKey, repositorySlug, id, sourceMatcherType, sourceMatcherValue, targetMatcherType, targetMatcherValue, reviewerIds, requiredApprovals, sourceMatcherDisplayId, targetMatcherDisplayId);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_deleteDefaultReviewerCondition",
+  "Delete a default reviewer condition from a Bitbucket repository by its ID.",
+  bitbucketToolSchemas.deleteDefaultReviewerCondition,
+  async ({ projectKey, repositorySlug, id }) => {
+    const result = await bitbucketService.deleteDefaultReviewerCondition(projectKey, repositorySlug, id);
+    return formatToolResponse(result);
+  }
+);
+
 await connectServer(server);


### PR DESCRIPTION
## Summary

Adds repository-scoped **default reviewer** governance tooling. Four new MCP tools:

- `bitbucket_getDefaultReviewerConditions` — list the conditions configured for a repo
- `bitbucket_createDefaultReviewerCondition` — create a condition: source/target ref matchers (by type + value), default reviewers (numeric user IDs), optional `requiredApprovals`
- `bitbucket_updateDefaultReviewerCondition` — replace an existing condition (the PUT replaces the whole condition, so the full desired set is sent)
- `bitbucket_deleteDefaultReviewerCondition` — delete a condition (compact ack)

Matchers are exposed ergonomically as a **type** (`ANY_REF`, `BRANCH`, `PATTERN`, `MODEL_CATEGORY`, `MODEL_BRANCH`) plus a **value**, and assembled into the ref-matcher shape (`{ id, displayId, type: { id } }`). Reviewers are numeric user IDs — resolve a username via `bitbucket_getUser`.

Backed by the generated `PullRequestsService.getPullRequestConditions1` / `createPullRequestCondition1` / `updatePullRequestCondition1` / `deletePullRequestCondition1`. No client regeneration required.

## Testing

- `npm run build` + `npm run test --workspace=@atlassian-dc-mcp/bitbucket` green (142 tests).
- Unit tests cover key normalization, matcher/reviewer body construction (including the optional `requiredApprovals` and matcher display-id defaulting), the id coercion to a number on delete, the ack shape, and error paths.
- Live-verified against a Bitbucket DC 9.x instance on `TEST/demo`: create `200` (ANY_REF source / BRANCH target, reviewer by id) → update `200` (requiredApprovals 1→2) → get `200` → delete `200` → re-list empty. The throwaway condition was cleaned up.