### PR TITLE
feat(bitbucket): add branch restriction tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { PullRequestsService, RepositoryService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,12 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  RepositoryService: {
+    getRestrictions1: jest.fn(),
+    createRestrictions1: jest.fn(),
+    getRestriction1: jest.fn(),
+    deleteRestriction1: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -2471,6 +2477,90 @@ describe('BitbucketService', () => {
         'TEST', 'test-repo', undefined, undefined,
         'refs/heads/feature', 'refs/heads/main'
       );
+    });
+  });
+
+  describe('branch restrictions', () => {
+    it('should get branch restrictions with filters and default limit', async () => {
+      const mockData = { values: [{ id: 1 }], isLastPage: true };
+      (RepositoryService.getRestrictions1 as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.getBranchRestrictions('test', 'Test-Repo', 'BRANCH', 'refs/heads/master', 'no-deletes');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(RepositoryService.getRestrictions1).toHaveBeenCalledWith(
+        'TEST', 'test-repo', 'BRANCH', 'refs/heads/master', 'no-deletes', undefined, 25
+      );
+    });
+
+    it('should create a branch restriction wrapped in a bulk array', async () => {
+      const mockData = { id: 1, type: 'no-deletes' };
+      (RepositoryService.createRestrictions1 as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.createBranchRestriction(
+        'test', 'Test-Repo', 'no-deletes', 'BRANCH', 'refs/heads/master', 'master', ['admin'], ['devs'], [7]
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(RepositoryService.createRestrictions1).toHaveBeenCalledWith('TEST', 'test-repo', [{
+        type: 'no-deletes',
+        matcher: { id: 'refs/heads/master', displayId: 'master', type: { id: 'BRANCH' } },
+        userSlugs: ['admin'],
+        groupNames: ['devs'],
+        accessKeyIds: [7]
+      }]);
+    });
+
+    it('should omit exemption fields when not provided', async () => {
+      (RepositoryService.createRestrictions1 as jest.Mock).mockResolvedValue({});
+
+      await bitbucketService.createBranchRestriction('TEST', 'test-repo', 'read-only', 'ANY_REF', 'ANY_REF');
+
+      expect(RepositoryService.createRestrictions1).toHaveBeenCalledWith('TEST', 'test-repo', [{
+        type: 'read-only',
+        matcher: { id: 'ANY_REF', displayId: 'ANY_REF', type: { id: 'ANY_REF' } }
+      }]);
+    });
+
+    it('should handle errors when creating a restriction', async () => {
+      (RepositoryService.createRestrictions1 as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.createBranchRestriction('TEST', 'test-repo', 'read-only', 'ANY_REF', 'ANY_REF');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should get a single restriction by id', async () => {
+      const mockData = { id: 5 };
+      (RepositoryService.getRestriction1 as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.getBranchRestriction('test', 'Test-Repo', '5');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(RepositoryService.getRestriction1).toHaveBeenCalledWith('TEST', '5', 'test-repo');
+    });
+
+    it('should delete a restriction and return an ack', async () => {
+      (RepositoryService.deleteRestriction1 as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.deleteBranchRestriction('test', 'Test-Repo', '5');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ deleted: true, id: '5' });
+      expect(RepositoryService.deleteRestriction1).toHaveBeenCalledWith('TEST', '5', 'test-repo');
+    });
+
+    it('should preserve the error field when delete fails', async () => {
+      (RepositoryService.deleteRestriction1 as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.deleteBranchRestriction('TEST', 'test-repo', '5');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
     });
   });
 });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -824,6 +824,112 @@ export class BitbucketService {
     return result;
   }
 
+  /**
+   * Get the branch (ref) restrictions configured for a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param matcherType Optional matcher type to filter on (BRANCH, PATTERN, MODEL_CATEGORY, MODEL_BRANCH)
+   * @param matcherId Optional matcher id to filter on (requires matcherType)
+   * @param type Optional restriction type to filter on (read-only, no-deletes, fast-forward-only, pull-request-only, no-creates)
+   * @param start Optional pagination start
+   * @param limit Optional pagination limit (defaults to the package page size)
+   * @returns Promise with the page of restrictions
+   */
+  async getBranchRestrictions(
+    projectKey: string,
+    repositorySlug: string,
+    matcherType?: 'BRANCH' | 'PATTERN' | 'MODEL_CATEGORY' | 'MODEL_BRANCH',
+    matcherId?: string,
+    type?: 'read-only' | 'no-deletes' | 'fast-forward-only' | 'pull-request-only' | 'no-creates',
+    start?: number,
+    limit?: number
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.getRestrictions1(
+        projectKey, repositorySlug, matcherType, matcherId, type, start, limit ?? this.getPageSize()
+      ),
+      'Error fetching branch restrictions'
+    );
+  }
+
+  /**
+   * Create a branch (ref) restriction for a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param type The restriction type (read-only, no-deletes, fast-forward-only, pull-request-only, no-creates)
+   * @param matcherType Matcher type for the restricted ref (ANY_REF, BRANCH, PATTERN, MODEL_CATEGORY, MODEL_BRANCH)
+   * @param matcherValue Matcher value (e.g. 'refs/heads/main', a pattern, or a model id)
+   * @param matcherDisplayId Optional display value for the matcher (defaults to the value)
+   * @param exemptUserSlugs Optional list of user slugs exempt from the restriction
+   * @param exemptGroupNames Optional list of group names exempt from the restriction
+   * @param exemptAccessKeyIds Optional list of SSH access key IDs exempt from the restriction
+   * @returns Promise with the created restriction
+   */
+  async createBranchRestriction(
+    projectKey: string,
+    repositorySlug: string,
+    type: string,
+    matcherType: string,
+    matcherValue: string,
+    matcherDisplayId?: string,
+    exemptUserSlugs?: string[],
+    exemptGroupNames?: string[],
+    exemptAccessKeyIds?: number[]
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const restriction: any = {
+      type,
+      matcher: {
+        id: matcherValue,
+        displayId: matcherDisplayId ?? matcherValue,
+        type: { id: matcherType },
+      },
+      ...(exemptUserSlugs ? { userSlugs: exemptUserSlugs } : {}),
+      ...(exemptGroupNames ? { groupNames: exemptGroupNames } : {}),
+      ...(exemptAccessKeyIds ? { accessKeyIds: exemptAccessKeyIds } : {}),
+    };
+    return handleApiOperation(
+      () => RepositoryService.createRestrictions1(projectKey, repositorySlug, [restriction]),
+      'Error creating branch restriction'
+    );
+  }
+
+  /**
+   * Get a single branch (ref) restriction by ID
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param id The restriction ID
+   * @returns Promise with the restriction
+   */
+  async getBranchRestriction(projectKey: string, repositorySlug: string, id: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => RepositoryService.getRestriction1(projectKey, id, repositorySlug),
+      'Error fetching branch restriction'
+    );
+  }
+
+  /**
+   * Delete a branch (ref) restriction by ID
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param id The restriction ID
+   * @returns Promise with a delete acknowledgement
+   */
+  async deleteBranchRestriction(projectKey: string, repositorySlug: string, id: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const result = await handleApiOperation(
+      () => RepositoryService.deleteRestriction1(projectKey, id, repositorySlug),
+      'Error deleting branch restriction'
+    );
+    return { ...result, data: { deleted: true, id } };
+  }
+
   async validateSetup(): Promise<void> {
     await __request(OpenAPI, {
       method: 'GET',
@@ -995,5 +1101,35 @@ export const bitbucketToolSchemas = {
   getInboxPullRequests: {
     start: z.number().optional().describe("Start number for the page (inclusive). If not passed, first page is assumed"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  getBranchRestrictions: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    matcherType: z.enum(['BRANCH', 'PATTERN', 'MODEL_CATEGORY', 'MODEL_BRANCH']).optional().describe("Filter by matcher type"),
+    matcherId: z.string().optional().describe("Filter by matcher id (requires matcherType)"),
+    type: z.enum(['read-only', 'no-deletes', 'fast-forward-only', 'pull-request-only', 'no-creates']).optional().describe("Filter by restriction type"),
+    start: z.number().optional().describe("Start number for pagination"),
+    limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  createBranchRestriction: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    type: z.enum(['read-only', 'no-deletes', 'fast-forward-only', 'pull-request-only', 'no-creates']).describe("The restriction type: read-only (prevent changes), no-deletes, fast-forward-only (prevent rewriting history), pull-request-only (prevent changes without a PR), no-creates"),
+    matcherType: z.enum(['ANY_REF', 'BRANCH', 'PATTERN', 'MODEL_CATEGORY', 'MODEL_BRANCH']).describe("Matcher type for the restricted ref"),
+    matcherValue: z.string().describe("Matcher value. For BRANCH use a ref id like 'refs/heads/main'; for PATTERN use the pattern; for MODEL_* use the model id; for ANY_REF use 'ANY_REF'."),
+    matcherDisplayId: z.string().optional().describe("Display value for the matcher (defaults to the matcher value, e.g. 'main' for 'refs/heads/main')"),
+    exemptUserSlugs: z.array(z.string()).optional().describe("User slugs exempt from the restriction"),
+    exemptGroupNames: z.array(z.string()).optional().describe("Group names exempt from the restriction"),
+    exemptAccessKeyIds: z.array(z.number()).optional().describe("SSH access key IDs exempt from the restriction")
+  },
+  getBranchRestriction: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    id: z.string().describe("The restriction ID")
+  },
+  deleteBranchRestriction: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    id: z.string().describe("The restriction ID")
   }
 };

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -218,4 +218,44 @@ server.tool(
   }
 );
 
+server.tool(
+  "bitbucket_getBranchRestrictions",
+  "List the branch (ref) restrictions configured for a Bitbucket repository. Requires REPO_ADMIN. Optionally filter by matcher type/id and restriction type.",
+  bitbucketToolSchemas.getBranchRestrictions,
+  async ({ projectKey, repositorySlug, matcherType, matcherId, type, start, limit }) => {
+    const result = await bitbucketService.getBranchRestrictions(projectKey, repositorySlug, matcherType, matcherId, type, start, limit);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_createBranchRestriction",
+  "Create a branch (ref) restriction (branch permission) on a Bitbucket repository. Requires REPO_ADMIN. The matcher is specified by type (ANY_REF/BRANCH/PATTERN/MODEL_CATEGORY/MODEL_BRANCH) and value; optionally exempt users, groups, or access keys.",
+  bitbucketToolSchemas.createBranchRestriction,
+  async ({ projectKey, repositorySlug, type, matcherType, matcherValue, matcherDisplayId, exemptUserSlugs, exemptGroupNames, exemptAccessKeyIds }) => {
+    const result = await bitbucketService.createBranchRestriction(projectKey, repositorySlug, type, matcherType, matcherValue, matcherDisplayId, exemptUserSlugs, exemptGroupNames, exemptAccessKeyIds);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_getBranchRestriction",
+  "Get a single branch (ref) restriction from a Bitbucket repository by its ID. Requires REPO_ADMIN.",
+  bitbucketToolSchemas.getBranchRestriction,
+  async ({ projectKey, repositorySlug, id }) => {
+    const result = await bitbucketService.getBranchRestriction(projectKey, repositorySlug, id);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_deleteBranchRestriction",
+  "Delete a branch (ref) restriction from a Bitbucket repository by its ID. Requires REPO_ADMIN.",
+  bitbucketToolSchemas.deleteBranchRestriction,
+  async ({ projectKey, repositorySlug, id }) => {
+    const result = await bitbucketService.deleteBranchRestriction(projectKey, repositorySlug, id);
+    return formatToolResponse(result);
+  }
+);
+
 await connectServer(server);


### PR DESCRIPTION
## Summary

Adds repository-scoped **branch (ref) restriction** (branch permission) governance tooling. Four new MCP tools:

- `bitbucket_getBranchRestrictions` — list restrictions; optional filters by matcher type/id and restriction type
- `bitbucket_createBranchRestriction` — create a restriction: `type` (read-only, no-deletes, fast-forward-only, pull-request-only, no-creates), a matcher (by type + value), and optional exempt users / groups / SSH access keys
- `bitbucket_getBranchRestriction` — get a single restriction by ID
- `bitbucket_deleteBranchRestriction` — delete a restriction (compact ack)

Matchers are exposed as a **type** (`ANY_REF`, `BRANCH`, `PATTERN`, `MODEL_CATEGORY`, `MODEL_BRANCH`) plus a **value**. The create endpoint is bulk, so a single restriction is wrapped in a one-element array and sent with the `application/vnd.atl.bitbucket.bulk+json` media type (handled by the generated client).

Backed by the generated `RepositoryService.getRestrictions1` / `createRestrictions1` / `getRestriction1` / `deleteRestriction1`. No client regeneration required.

## Testing

- `npm run build` + `npm run test --workspace=@atlassian-dc-mcp/bitbucket` green (142 tests).
- Unit tests cover key normalization, matcher + exemption body construction, the bulk array wrapping, the default page size on list, the ack shape, and error paths.
- Live-verified against a Bitbucket DC 9.x instance on `TEST/demo`: create `200` (no-deletes on `refs/heads/master`, returns the restriction) → get `200` → list `200` → delete `204` → re-get `404`. The throwaway restriction was cleaned up.