### PR TITLE
feat(bitbucket): add required-builds merge check tools

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { BuildsAndDeploymentsService, PullRequestsService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,12 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  BuildsAndDeploymentsService: {
+    getPageOfRequiredBuildsMergeChecks: jest.fn(),
+    createRequiredBuildsMergeCheck: jest.fn(),
+    updateRequiredBuildsMergeCheck: jest.fn(),
+    deleteRequiredBuildsMergeCheck: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -2471,6 +2477,91 @@ describe('BitbucketService', () => {
         'TEST', 'test-repo', undefined, undefined,
         'refs/heads/feature', 'refs/heads/main'
       );
+    });
+  });
+
+  describe('required builds merge checks', () => {
+    it('should get merge checks with the default page size', async () => {
+      const mockData = { values: [{ id: 1 }], isLastPage: true };
+      (BuildsAndDeploymentsService.getPageOfRequiredBuildsMergeChecks as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.getRequiredBuildsMergeChecks('test', 'Test-Repo');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(BuildsAndDeploymentsService.getPageOfRequiredBuildsMergeChecks).toHaveBeenCalledWith('TEST', 'test-repo', undefined, 25);
+    });
+
+    it('should create a merge check with a built body', async () => {
+      const mockData = { id: 1 };
+      (BuildsAndDeploymentsService.createRequiredBuildsMergeCheck as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.createRequiredBuildsMergeCheck(
+        'test', 'Test-Repo', ['build-foo'], 'BRANCH', 'refs/heads/master', 'master', 'BRANCH', 'refs/heads/dev', 'dev'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(BuildsAndDeploymentsService.createRequiredBuildsMergeCheck).toHaveBeenCalledWith('TEST', 'test-repo', {
+        buildParentKeys: ['build-foo'],
+        refMatcher: { id: 'refs/heads/master', displayId: 'master', type: { id: 'BRANCH' } },
+        exemptRefMatcher: { id: 'refs/heads/dev', displayId: 'dev', type: { id: 'BRANCH' } }
+      });
+    });
+
+    it('should omit the exempt matcher when not fully provided', async () => {
+      (BuildsAndDeploymentsService.createRequiredBuildsMergeCheck as jest.Mock).mockResolvedValue({});
+
+      await bitbucketService.createRequiredBuildsMergeCheck('TEST', 'test-repo', ['build-foo'], 'ANY_REF', 'ANY_REF');
+
+      expect(BuildsAndDeploymentsService.createRequiredBuildsMergeCheck).toHaveBeenCalledWith('TEST', 'test-repo', {
+        buildParentKeys: ['build-foo'],
+        refMatcher: { id: 'ANY_REF', displayId: 'ANY_REF', type: { id: 'ANY_REF' } }
+      });
+    });
+
+    it('should handle errors when creating a merge check', async () => {
+      (BuildsAndDeploymentsService.createRequiredBuildsMergeCheck as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.createRequiredBuildsMergeCheck('TEST', 'test-repo', ['build-foo'], 'ANY_REF', 'ANY_REF');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should update a merge check coercing the id to a number', async () => {
+      const mockData = { id: 1 };
+      (BuildsAndDeploymentsService.updateRequiredBuildsMergeCheck as jest.Mock).mockResolvedValue(mockData);
+
+      const result = await bitbucketService.updateRequiredBuildsMergeCheck(
+        'test', 'Test-Repo', '1', ['build-foo', 'build-bar'], 'BRANCH', 'refs/heads/master', 'master'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(BuildsAndDeploymentsService.updateRequiredBuildsMergeCheck).toHaveBeenCalledWith('TEST', 1, 'test-repo', {
+        buildParentKeys: ['build-foo', 'build-bar'],
+        refMatcher: { id: 'refs/heads/master', displayId: 'master', type: { id: 'BRANCH' } }
+      });
+    });
+
+    it('should delete a merge check coercing the id and return an ack', async () => {
+      (BuildsAndDeploymentsService.deleteRequiredBuildsMergeCheck as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await bitbucketService.deleteRequiredBuildsMergeCheck('test', 'Test-Repo', '1');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ deleted: true, id: '1' });
+      expect(BuildsAndDeploymentsService.deleteRequiredBuildsMergeCheck).toHaveBeenCalledWith('TEST', 1, 'test-repo');
+    });
+
+    it('should preserve the error field when delete fails', async () => {
+      (BuildsAndDeploymentsService.deleteRequiredBuildsMergeCheck as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.deleteRequiredBuildsMergeCheck('TEST', 'test-repo', '1');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
     });
   });
 });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { OpenAPI, ProjectService, PullRequestsService, RepositoryService } from './bitbucket-client/index.js';
+import { BuildsAndDeploymentsService, OpenAPI, ProjectService, PullRequestsService, RepositoryService } from './bitbucket-client/index.js';
 import { request as __request } from './bitbucket-client/core/request.js';
 import { handleApiOperation, resolveOpenApiBase } from '@atlassian-dc-mcp/common';
 import { simplifyInboxPullRequests } from './inbox-pr-mapper.js';
@@ -824,6 +824,144 @@ export class BitbucketService {
     return result;
   }
 
+  /**
+   * Get the required-builds merge checks configured for a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param start Optional pagination start
+   * @param limit Optional pagination limit (defaults to the package page size)
+   * @returns Promise with the page of required-builds merge checks
+   */
+  async getRequiredBuildsMergeChecks(projectKey: string, repositorySlug: string, start?: number, limit?: number) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    return handleApiOperation(
+      () => BuildsAndDeploymentsService.getPageOfRequiredBuildsMergeChecks(
+        projectKey, repositorySlug, start, limit ?? this.getPageSize()
+      ),
+      'Error fetching required builds merge checks'
+    );
+  }
+
+  /**
+   * Create a required-builds merge check for a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param buildParentKeys Non-empty list of build parent keys that must have green builds for the check to pass
+   * @param refMatcherType Matcher type for the target ref (ANY_REF, BRANCH, PATTERN, MODEL_CATEGORY, MODEL_BRANCH)
+   * @param refMatcherValue Matcher value for the target ref (e.g. 'refs/heads/main')
+   * @param refMatcherDisplayId Optional display value for the ref matcher (defaults to the value)
+   * @param exemptRefMatcherType Optional matcher type for the exempt source ref
+   * @param exemptRefMatcherValue Optional matcher value for the exempt source ref
+   * @param exemptRefMatcherDisplayId Optional display value for the exempt ref matcher
+   * @returns Promise with the created merge check
+   */
+  async createRequiredBuildsMergeCheck(
+    projectKey: string,
+    repositorySlug: string,
+    buildParentKeys: string[],
+    refMatcherType: string,
+    refMatcherValue: string,
+    refMatcherDisplayId?: string,
+    exemptRefMatcherType?: string,
+    exemptRefMatcherValue?: string,
+    exemptRefMatcherDisplayId?: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody = this.buildRequiredBuildsBody(
+      buildParentKeys, refMatcherType, refMatcherValue, refMatcherDisplayId,
+      exemptRefMatcherType, exemptRefMatcherValue, exemptRefMatcherDisplayId
+    );
+    return handleApiOperation(
+      () => BuildsAndDeploymentsService.createRequiredBuildsMergeCheck(projectKey, repositorySlug, requestBody),
+      'Error creating required builds merge check'
+    );
+  }
+
+  /**
+   * Update an existing required-builds merge check (replaces the check)
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param id The ID of the merge check to update
+   * @param buildParentKeys Non-empty list of build parent keys
+   * @param refMatcherType Matcher type for the target ref
+   * @param refMatcherValue Matcher value for the target ref
+   * @param refMatcherDisplayId Optional display value for the ref matcher
+   * @param exemptRefMatcherType Optional matcher type for the exempt source ref
+   * @param exemptRefMatcherValue Optional matcher value for the exempt source ref
+   * @param exemptRefMatcherDisplayId Optional display value for the exempt ref matcher
+   * @returns Promise with the updated merge check
+   */
+  async updateRequiredBuildsMergeCheck(
+    projectKey: string,
+    repositorySlug: string,
+    id: string,
+    buildParentKeys: string[],
+    refMatcherType: string,
+    refMatcherValue: string,
+    refMatcherDisplayId?: string,
+    exemptRefMatcherType?: string,
+    exemptRefMatcherValue?: string,
+    exemptRefMatcherDisplayId?: string
+  ) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const requestBody = this.buildRequiredBuildsBody(
+      buildParentKeys, refMatcherType, refMatcherValue, refMatcherDisplayId,
+      exemptRefMatcherType, exemptRefMatcherValue, exemptRefMatcherDisplayId
+    );
+    return handleApiOperation(
+      () => BuildsAndDeploymentsService.updateRequiredBuildsMergeCheck(projectKey, Number(id), repositorySlug, requestBody),
+      'Error updating required builds merge check'
+    );
+  }
+
+  /**
+   * Delete a required-builds merge check by ID
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param id The ID of the merge check to delete
+   * @returns Promise with a delete acknowledgement
+   */
+  async deleteRequiredBuildsMergeCheck(projectKey: string, repositorySlug: string, id: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    const result = await handleApiOperation(
+      () => BuildsAndDeploymentsService.deleteRequiredBuildsMergeCheck(projectKey, Number(id), repositorySlug),
+      'Error deleting required builds merge check'
+    );
+    return { ...result, data: { deleted: true, id } };
+  }
+
+  private buildRequiredBuildsBody(
+    buildParentKeys: string[],
+    refMatcherType: string,
+    refMatcherValue: string,
+    refMatcherDisplayId?: string,
+    exemptRefMatcherType?: string,
+    exemptRefMatcherValue?: string,
+    exemptRefMatcherDisplayId?: string
+  ): any {
+    return {
+      buildParentKeys,
+      refMatcher: {
+        id: refMatcherValue,
+        displayId: refMatcherDisplayId ?? refMatcherValue,
+        type: { id: refMatcherType },
+      },
+      ...(exemptRefMatcherType && exemptRefMatcherValue
+        ? {
+            exemptRefMatcher: {
+              id: exemptRefMatcherValue,
+              displayId: exemptRefMatcherDisplayId ?? exemptRefMatcherValue,
+              type: { id: exemptRefMatcherType },
+            },
+          }
+        : {}),
+    };
+  }
+
   async validateSetup(): Promise<void> {
     await __request(OpenAPI, {
       method: 'GET',
@@ -995,5 +1133,39 @@ export const bitbucketToolSchemas = {
   getInboxPullRequests: {
     start: z.number().optional().describe("Start number for the page (inclusive). If not passed, first page is assumed"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  getRequiredBuildsMergeChecks: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    start: z.number().optional().describe("Start number for pagination"),
+    limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  createRequiredBuildsMergeCheck: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    buildParentKeys: z.array(z.string()).describe("Non-empty list of build parent keys that must have green builds for the check to pass"),
+    refMatcherType: z.enum(['ANY_REF', 'BRANCH', 'PATTERN', 'MODEL_CATEGORY', 'MODEL_BRANCH']).describe("Matcher type for the target ref the check applies to"),
+    refMatcherValue: z.string().describe("Matcher value for the target ref. For BRANCH use a ref id like 'refs/heads/main'; for PATTERN use the pattern; for MODEL_* use the model id; for ANY_REF use 'ANY_REF'."),
+    refMatcherDisplayId: z.string().optional().describe("Display value for the ref matcher (defaults to the matcher value)"),
+    exemptRefMatcherType: z.enum(['ANY_REF', 'BRANCH', 'PATTERN', 'MODEL_CATEGORY', 'MODEL_BRANCH']).optional().describe("Matcher type for source refs exempt from the check"),
+    exemptRefMatcherValue: z.string().optional().describe("Matcher value for source refs exempt from the check"),
+    exemptRefMatcherDisplayId: z.string().optional().describe("Display value for the exempt ref matcher (defaults to its value)")
+  },
+  updateRequiredBuildsMergeCheck: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    id: z.string().describe("The ID of the merge check to update"),
+    buildParentKeys: z.array(z.string()).describe("Non-empty list of build parent keys. The update replaces the whole check, so pass the complete desired list."),
+    refMatcherType: z.enum(['ANY_REF', 'BRANCH', 'PATTERN', 'MODEL_CATEGORY', 'MODEL_BRANCH']).describe("Matcher type for the target ref"),
+    refMatcherValue: z.string().describe("Matcher value for the target ref"),
+    refMatcherDisplayId: z.string().optional().describe("Display value for the ref matcher (defaults to the matcher value)"),
+    exemptRefMatcherType: z.enum(['ANY_REF', 'BRANCH', 'PATTERN', 'MODEL_CATEGORY', 'MODEL_BRANCH']).optional().describe("Matcher type for source refs exempt from the check"),
+    exemptRefMatcherValue: z.string().optional().describe("Matcher value for source refs exempt from the check"),
+    exemptRefMatcherDisplayId: z.string().optional().describe("Display value for the exempt ref matcher (defaults to its value)")
+  },
+  deleteRequiredBuildsMergeCheck: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    id: z.string().describe("The ID of the merge check to delete")
   }
 };

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -218,4 +218,44 @@ server.tool(
   }
 );
 
+server.tool(
+  "bitbucket_getRequiredBuildsMergeChecks",
+  "List the required-builds merge checks configured for a Bitbucket repository. Each check requires green builds for the given build keys before a PR targeting the matched ref can be merged.",
+  bitbucketToolSchemas.getRequiredBuildsMergeChecks,
+  async ({ projectKey, repositorySlug, start, limit }) => {
+    const result = await bitbucketService.getRequiredBuildsMergeChecks(projectKey, repositorySlug, start, limit);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_createRequiredBuildsMergeCheck",
+  "Create a required-builds merge check on a Bitbucket repository. Requires REPO_ADMIN. Provide the build parent keys that must be green and a target ref matcher (type + value); optionally exempt source refs.",
+  bitbucketToolSchemas.createRequiredBuildsMergeCheck,
+  async ({ projectKey, repositorySlug, buildParentKeys, refMatcherType, refMatcherValue, refMatcherDisplayId, exemptRefMatcherType, exemptRefMatcherValue, exemptRefMatcherDisplayId }) => {
+    const result = await bitbucketService.createRequiredBuildsMergeCheck(projectKey, repositorySlug, buildParentKeys, refMatcherType, refMatcherValue, refMatcherDisplayId, exemptRefMatcherType, exemptRefMatcherValue, exemptRefMatcherDisplayId);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_updateRequiredBuildsMergeCheck",
+  "Update a required-builds merge check on a Bitbucket repository. Requires REPO_ADMIN. This replaces the whole check, so provide the complete desired build keys and matcher.",
+  bitbucketToolSchemas.updateRequiredBuildsMergeCheck,
+  async ({ projectKey, repositorySlug, id, buildParentKeys, refMatcherType, refMatcherValue, refMatcherDisplayId, exemptRefMatcherType, exemptRefMatcherValue, exemptRefMatcherDisplayId }) => {
+    const result = await bitbucketService.updateRequiredBuildsMergeCheck(projectKey, repositorySlug, id, buildParentKeys, refMatcherType, refMatcherValue, refMatcherDisplayId, exemptRefMatcherType, exemptRefMatcherValue, exemptRefMatcherDisplayId);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "bitbucket_deleteRequiredBuildsMergeCheck",
+  "Delete a required-builds merge check from a Bitbucket repository by its ID. Requires REPO_ADMIN.",
+  bitbucketToolSchemas.deleteRequiredBuildsMergeCheck,
+  async ({ projectKey, repositorySlug, id }) => {
+    const result = await bitbucketService.deleteRequiredBuildsMergeCheck(projectKey, repositorySlug, id);
+    return formatToolResponse(result);
+  }
+);
+
 await connectServer(server);


### PR DESCRIPTION
## Summary

Adds repository-scoped **required-builds merge check** governance tooling. Four new MCP tools:

- `bitbucket_getRequiredBuildsMergeChecks` — list the checks configured for a repo
- `bitbucket_createRequiredBuildsMergeCheck` — create a check: `buildParentKeys` that must be green + a target ref matcher (type + value), plus an optional exempt source ref matcher
- `bitbucket_updateRequiredBuildsMergeCheck` — replace an existing check
- `bitbucket_deleteRequiredBuildsMergeCheck` — delete a check (compact ack)

Matchers are exposed as a **type** (`ANY_REF`, `BRANCH`, `PATTERN`, `MODEL_CATEGORY`, `MODEL_BRANCH`) plus a **value**, assembled into the ref-matcher shape.

Backed by the generated `BuildsAndDeploymentsService.getPageOfRequiredBuildsMergeChecks` / `createRequiredBuildsMergeCheck` / `updateRequiredBuildsMergeCheck` / `deleteRequiredBuildsMergeCheck`. No client regeneration required.

## Testing

- `npm run build` + `npm run test --workspace=@atlassian-dc-mcp/bitbucket` green (142 tests).
- Unit tests cover key normalization, ref + exempt matcher body construction, the default page size on list, id coercion to a number on update/delete, the ack shape, and error paths.
- Live-verified against a Bitbucket DC 9.x instance on `TEST/demo`: list `200` → create `200` (build key + BRANCH matcher on `refs/heads/master`) → update `200` (build key list changed) → delete `204`. The throwaway check was cleaned up.