### PR TITLE
feat(bitbucket): add code search tool

### DIFF
--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -2473,4 +2473,63 @@ describe('BitbucketService', () => {
       );
     });
   });
+
+  describe('searchCode', () => {
+    const { request: mockRequest } = require('../bitbucket-client/core/request.js');
+
+    it('should search code with the default page size', async () => {
+      const mockData = { code: { count: 1, values: [{ repository: { slug: 'demo' } }] } };
+      mockRequest.mockResolvedValue(mockData);
+
+      const result = await bitbucketService.searchCode('app');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.any(Object),
+        {
+          method: 'POST',
+          url: '/search/latest/search',
+          body: {
+            query: 'app',
+            entities: { code: {} },
+            limits: { primary: 25 }
+          },
+          mediaType: 'application/json',
+          errors: {
+            400: 'The search query was malformed.',
+            401: 'The currently authenticated user is not permitted to search.',
+          },
+        }
+      );
+    });
+
+    it('should pass explicit primary and secondary limits', async () => {
+      mockRequest.mockResolvedValue({ code: { count: 0, values: [] } });
+
+      await bitbucketService.searchCode('repo:demo TODO', 10, 5);
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          method: 'POST',
+          url: '/search/latest/search',
+          body: {
+            query: 'repo:demo TODO',
+            entities: { code: {} },
+            limits: { primary: 10, secondary: 5 }
+          },
+        })
+      );
+    });
+
+    it('should handle errors when searching', async () => {
+      mockRequest.mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.searchCode('app');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
 });

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -824,6 +824,46 @@ export class BitbucketService {
     return result;
   }
 
+  /**
+   * Search code across Bitbucket using the search REST module.
+   *
+   * The query string supports Bitbucket search modifiers, e.g. `project:TEST`,
+   * `repo:projectkey/repositoryslug` (e.g. `repo:TEST/demo`), `ext:js`, so scoping to a
+   * project or repository is done inside the query text. Note: `repo:` must include the
+   * project key (`repo:KEY/slug`); a bare `repo:slug` is rejected by the server.
+   *
+   * Note: the `/rest/search` endpoint is a separate Bitbucket REST module that is not part of
+   * the generated client, so this is issued via the low-level request helper (same approach as
+   * the dashboard/inbox endpoints).
+   *
+   * @param query The search query (may include modifiers like `repo:`, `project:`, `ext:`)
+   * @param limit Optional primary result limit (defaults to the package page size)
+   * @param secondaryLimit Optional secondary limit (number of hit contexts per match)
+   * @returns Promise with the code search results
+   */
+  async searchCode(query: string, limit?: number, secondaryLimit?: number) {
+    return handleApiOperation(
+      () => __request(OpenAPI, {
+        method: 'POST',
+        url: '/search/latest/search',
+        body: {
+          query,
+          entities: { code: {} },
+          limits: {
+            primary: limit ?? this.getPageSize(),
+            ...(secondaryLimit !== undefined ? { secondary: secondaryLimit } : {}),
+          },
+        },
+        mediaType: 'application/json',
+        errors: {
+          400: 'The search query was malformed.',
+          401: 'The currently authenticated user is not permitted to search.',
+        },
+      }),
+      'Error searching code'
+    );
+  }
+
   async validateSetup(): Promise<void> {
     await __request(OpenAPI, {
       method: 'GET',
@@ -995,5 +1035,10 @@ export const bitbucketToolSchemas = {
   getInboxPullRequests: {
     start: z.number().optional().describe("Start number for the page (inclusive). If not passed, first page is assumed"),
     limit: z.number().optional().describe("Number of items to return. If not passed, the package default page size is used.")
+  },
+  searchCode: {
+    query: z.string().describe("The search query. Supports Bitbucket search modifiers, e.g. 'project:TEST authenticate', 'repo:TEST/demo TODO' (the repo modifier must be 'repo:projectkey/repositoryslug'), 'ext:ts useState'. Scope to a project or repository inside the query text."),
+    limit: z.number().optional().describe("Maximum number of matching files to return. If not passed, the package default page size is used."),
+    secondaryLimit: z.number().optional().describe("Maximum number of hit contexts (matching code snippets) to return per file")
   }
 };

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -218,4 +218,14 @@ server.tool(
   }
 );
 
+server.tool(
+  "bitbucket_searchCode",
+  "Search code across Bitbucket. The query supports search modifiers like 'project:<key>', 'repo:<key>/<slug>', and 'ext:<extension>' to scope or filter results (e.g. 'project:TEST authenticate', 'repo:TEST/demo ext:js TODO'). NOTE: the 'repo:' modifier requires the project key — 'repo:projectkey/repositoryslug', not a bare slug. Returns matching files with hit contexts (snippets).",
+  bitbucketToolSchemas.searchCode,
+  async ({ query, limit, secondaryLimit }) => {
+    const result = await bitbucketService.searchCode(query, limit, secondaryLimit);
+    return formatToolResponse(result);
+  }
+);
+
 await connectServer(server);


### PR DESCRIPTION
## Summary

Adds `bitbucket_searchCode` — search code across Bitbucket via the `/rest/search` module. The query supports Bitbucket search modifiers, so scoping/filtering is done inside the query text:

- `project:TEST authenticate`
- `repo:TEST/demo TODO` — the `repo:` modifier requires the **project key**: `repo:projectkey/repositoryslug`, not a bare slug
- `ext:ts useState`

Optional `limit` (primary result count) and `secondaryLimit` (hit contexts per file). Returns matching files with their hit contexts (snippets).

### Implementation note — no client regeneration

The `/rest/search` endpoint is a **separate Bitbucket REST module** that is not part of the generated OpenAPI client — there is no search service class, and the repository ships the generated client checked-in with no codegen tooling or source spec. Rather than stand up a full regeneration pipeline for a single endpoint (and risk churn across unrelated generated files), this tool issues the request through the low-level `__request` helper — the same escape hatch already used by `getDashboardPullRequests` and `getInboxPullRequests`. The behaviour is identical to a generated method; only the wiring differs.

## Testing

- `npm run build` + `npm run test --workspace=@atlassian-dc-mcp/bitbucket` green (138 tests).
- Unit tests cover the default page size (`limits.primary`), explicit primary/secondary limits, the request shape, and the error path.
- Live-verified against a Bitbucket DC 9.x instance: `POST /rest/search/latest/search` returns `200` and finds the match in `TEST/demo` for a plain query, a `project:TEST` query, and a `repo:TEST/demo` query. Confirmed that a bare `repo:demo` is rejected by the server (`400` — "repo: without a project: modifier"), which is documented in the tool description.