### PR TITLE
feat(jira): add issue link and unlink tools

### DIFF
--- a/packages/jira/README.md
+++ b/packages/jira/README.md
@@ -115,6 +115,7 @@ Alternatively, you can use `JIRA_API_BASE_PATH` instead of `JIRA_HOST` to specif
 - Get issue comments
 - Create and update issues
 - Add comments to issues
+- Link and unlink issues
 
 ## Setup
 
@@ -247,3 +248,26 @@ Parameters:
 - `issueKey` (string, required): The issue key (e.g., "PROJECT-123")
 - `transitionId` (string, required): Transition ID returned by `jira_getTransitions`
 - `fields` (object, optional): Additional fields required by the transition screen
+
+#### 9. jira_getIssueLinkTypes
+
+Get the list of available issue link types (e.g., "Blocks", "Relates", "Duplicate") in the JIRA Data Center edition instance. Use this to discover valid link type names before calling `jira_linkIssues`.
+
+Parameters: none
+
+#### 10. jira_linkIssues
+
+Create a link between two JIRA issues in the JIRA Data Center edition instance.
+
+Parameters:
+- `inwardIssueKey` (string, required): Key of the inward issue — the one the inward link description applies to (e.g., the issue that "is blocked by"). Example: "PROJECT-123"
+- `outwardIssueKey` (string, required): Key of the outward issue — the one the outward link description applies to (e.g., the issue that "blocks"). Example: "PROJECT-456"
+- `linkType` (string, required): Name of the issue link type to apply (e.g., "Blocks", "Relates"). Use `jira_getIssueLinkTypes` to discover valid names for this JIRA installation.
+- `comment` (string, optional): Comment added to the inward issue when the link is created, in JIRA Wiki Markup
+
+#### 11. jira_unlinkIssues
+
+Delete an existing link between two JIRA issues in the JIRA Data Center edition instance.
+
+Parameters:
+- `linkId` (string, required): The id of the issue link to delete. Link ids are found in the `issuelinks` field of an issue (retrieve it via `jira_getIssue` with the `issuelinks` field).

--- a/packages/jira/src/__tests__/jira-service.test.ts
+++ b/packages/jira/src/__tests__/jira-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { JiraService } from '../jira-service.js';
-import { IssueService, OpenAPI, SearchService } from '../jira-client/index.js';
+import { IssueLinkService, IssueLinkTypeService, IssueService, OpenAPI, SearchService } from '../jira-client/index.js';
 import { request as __request } from '../jira-client/core/request.js';
 
 jest.mock('../jira-client/core/request.js', () => ({
@@ -22,6 +22,13 @@ jest.mock('../jira-client/index.js', () => ({
   },
   SearchService: {
     searchUsingSearchRequest: jest.fn(),
+  },
+  IssueLinkService: {
+    linkIssues: jest.fn(),
+    deleteIssueLink: jest.fn(),
+  },
+  IssueLinkTypeService: {
+    getIssueLinkTypes: jest.fn(),
   },
   OpenAPI: {
     BASE: '',
@@ -422,6 +429,104 @@ describe('JiraService', () => {
 
       const missingVars = JiraService.validateConfig();
       expect(missingVars).toEqual([]);
+    });
+  });
+
+  describe('getIssueLinkTypes', () => {
+    it('should return the available issue link types', async () => {
+      const mockLinkTypes = {
+        issueLinkTypes: [
+          { id: '10000', name: 'Blocks', inward: 'is blocked by', outward: 'blocks' },
+          { id: '10001', name: 'Relates', inward: 'relates to', outward: 'relates to' },
+        ],
+      };
+      (IssueLinkTypeService.getIssueLinkTypes as jest.Mock).mockResolvedValue(mockLinkTypes);
+
+      const result = await jiraService.getIssueLinkTypes();
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockLinkTypes);
+      expect(IssueLinkTypeService.getIssueLinkTypes).toHaveBeenCalledWith();
+    });
+
+    it('should handle errors when issue linking is disabled', async () => {
+      (IssueLinkTypeService.getIssueLinkTypes as jest.Mock).mockRejectedValue(new Error('Issue linking is disabled'));
+
+      const result = await jiraService.getIssueLinkTypes();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Issue linking is disabled');
+    });
+  });
+
+  describe('linkIssues', () => {
+    it('should create a link between two issues', async () => {
+      (IssueLinkService.linkIssues as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await jiraService.linkIssues({
+        inwardIssueKey: 'PROJ-123',
+        outwardIssueKey: 'PROJ-456',
+        linkType: 'Blocks',
+      });
+
+      expect(result.success).toBe(true);
+      expect(IssueLinkService.linkIssues).toHaveBeenCalledWith({
+        type: { name: 'Blocks' },
+        inwardIssue: { key: 'PROJ-123' },
+        outwardIssue: { key: 'PROJ-456' },
+      });
+    });
+
+    it('should include an optional comment on the inward issue', async () => {
+      (IssueLinkService.linkIssues as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await jiraService.linkIssues({
+        inwardIssueKey: 'PROJ-123',
+        outwardIssueKey: 'PROJ-456',
+        linkType: 'Relates',
+        comment: 'Linking these for tracking',
+      });
+
+      expect(result.success).toBe(true);
+      expect(IssueLinkService.linkIssues).toHaveBeenCalledWith({
+        type: { name: 'Relates' },
+        inwardIssue: { key: 'PROJ-123' },
+        outwardIssue: { key: 'PROJ-456' },
+        comment: { body: 'Linking these for tracking' },
+      });
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (IssueLinkService.linkIssues as jest.Mock).mockRejectedValue(new Error('Issue link type not found'));
+
+      const result = await jiraService.linkIssues({
+        inwardIssueKey: 'PROJ-123',
+        outwardIssueKey: 'PROJ-456',
+        linkType: 'Nonexistent',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Issue link type not found');
+    });
+  });
+
+  describe('unlinkIssues', () => {
+    it('should delete an issue link by id', async () => {
+      (IssueLinkService.deleteIssueLink as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await jiraService.unlinkIssues('10500');
+
+      expect(result.success).toBe(true);
+      expect(IssueLinkService.deleteIssueLink).toHaveBeenCalledWith('10500');
+    });
+
+    it('should handle errors when the link id is invalid', async () => {
+      (IssueLinkService.deleteIssueLink as jest.Mock).mockRejectedValue(new Error('Invalid issue link id'));
+
+      const result = await jiraService.unlinkIssues('bad-id');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid issue link id');
     });
   });
 });

--- a/packages/jira/src/__tests__/response-body.test.ts
+++ b/packages/jira/src/__tests__/response-body.test.ts
@@ -1,0 +1,43 @@
+import { getResponseBody } from '../jira-client/core/request.js';
+
+function jsonResponse(status: number, body: string): Response {
+  return {
+    status,
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    text: async () => body,
+    json: async () => JSON.parse(body),
+  } as unknown as Response;
+}
+
+describe('getResponseBody', () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  afterEach(() => {
+    errorSpy.mockClear();
+  });
+
+  afterAll(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('returns undefined for an empty JSON body without logging (e.g. POST /issueLink)', async () => {
+    const result = await getResponseBody(jsonResponse(201, ''));
+
+    expect(result).toBeUndefined();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('parses a non-empty JSON body', async () => {
+    const result = await getResponseBody(jsonResponse(200, '{"id":"1158012"}'));
+
+    expect(result).toEqual({ id: '1158012' });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined for a 204 No Content response (e.g. DELETE /issueLink)', async () => {
+    const result = await getResponseBody(jsonResponse(204, ''));
+
+    expect(result).toBeUndefined();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/jira/src/index.ts
+++ b/packages/jira/src/index.ts
@@ -117,4 +117,34 @@ server.tool(
   }
 );
 
+server.tool(
+  "jira_getIssueLinkTypes",
+  `Get the list of available issue link types (e.g. Blocks, Relates, Duplicate) in the ${jiraInstanceType}. Use this to discover valid link type names before calling jira_linkIssues.`,
+  jiraToolSchemas.getIssueLinkTypes,
+  async () => {
+    const result = await jiraService.getIssueLinkTypes();
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "jira_linkIssues",
+  `Create a link between two JIRA issues in the ${jiraInstanceType}. Use jira_getIssueLinkTypes to find valid link type names.`,
+  jiraToolSchemas.linkIssues,
+  async (params) => {
+    const result = await jiraService.linkIssues(params);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
+  "jira_unlinkIssues",
+  `Delete an existing link between two JIRA issues in the ${jiraInstanceType}. Requires the issue link id (found in the 'issuelinks' field of an issue).`,
+  jiraToolSchemas.unlinkIssues,
+  async ({ linkId }) => {
+    const result = await jiraService.unlinkIssues(linkId);
+    return formatToolResponse(result);
+  }
+);
+
 await connectServer(server);

--- a/packages/jira/src/jira-client/core/request.ts
+++ b/packages/jira/src/jira-client/core/request.ts
@@ -257,7 +257,11 @@ export const getResponseBody = async (response: Response): Promise<any> => {
                 const jsonTypes = ['application/json', 'application/problem+json']
                 const isJSON = jsonTypes.some(type => contentType.toLowerCase().startsWith(type));
                 if (isJSON) {
-                    return await response.json();
+                    // Some endpoints (e.g. POST /issueLink) return a success status with
+                    // Content-Type: application/json but an empty body; parsing that as JSON
+                    // throws. Read the text first and only parse when there is something to parse.
+                    const text = await response.text();
+                    return text ? JSON.parse(text) : undefined;
                 } else {
                     return await response.text();
                 }

--- a/packages/jira/src/jira-service.ts
+++ b/packages/jira/src/jira-service.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { handleApiOperation, resolveOpenApiBase } from '@atlassian-dc-mcp/common';
-import { IssueService, MyselfService, OpenAPI, SearchService } from './jira-client/index.js';
+import { IssueLinkService, IssueLinkTypeService, IssueService, MyselfService, OpenAPI, SearchService } from './jira-client/index.js';
 import { request as __request } from './jira-client/core/request.js';
 import type { StringList } from './jira-client/models/StringList.js';
 import { getDefaultPageSize, getMissingConfig, JIRA_PRODUCT } from './config.js';
@@ -177,6 +177,36 @@ export class JiraService {
     }, 'Error transitioning issue');
   }
 
+  async getIssueLinkTypes() {
+    return handleApiOperation(
+      () => IssueLinkTypeService.getIssueLinkTypes(),
+      'Error getting issue link types'
+    );
+  }
+
+  async linkIssues(params: {
+    inwardIssueKey: string;
+    outwardIssueKey: string;
+    linkType: string;
+    comment?: string;
+  }) {
+    return handleApiOperation(() => {
+      return IssueLinkService.linkIssues({
+        type: { name: params.linkType },
+        inwardIssue: { key: params.inwardIssueKey },
+        outwardIssue: { key: params.outwardIssueKey },
+        ...(params.comment ? { comment: { body: params.comment } } : {}),
+      });
+    }, 'Error linking issues');
+  }
+
+  async unlinkIssues(linkId: string) {
+    return handleApiOperation(
+      () => IssueLinkService.deleteIssueLink(linkId),
+      'Error unlinking issues'
+    );
+  }
+
   async validateSetup(): Promise<void> {
     await MyselfService.getUser();
   }
@@ -236,5 +266,15 @@ export const jiraToolSchemas = {
     transitionId: z.string().describe("The ID of the transition to perform. Use jira_getTransitions to find available transitions and their IDs."),
     fields: z.record(z.any()).optional().describe("Optional fields required by the transition screen. Use jira_getTransitions to see which fields are available for each transition."),
     customFields: z.record(z.any()).optional().describe("Optional fields merged into the JIRA transition payload. Can be used for update operations such as comments. Example: {'update': {'comment': [{'add': {'body': 'text'}}]}}")
+  },
+  getIssueLinkTypes: {},
+  linkIssues: {
+    inwardIssueKey: z.string().describe("Key of the inward issue (the one the inward link description applies to, e.g. the issue that 'is blocked by'). Example: PROJ-123"),
+    outwardIssueKey: z.string().describe("Key of the outward issue (the one the outward link description applies to, e.g. the issue that 'blocks'). Example: PROJ-456"),
+    linkType: z.string().describe("Name of the issue link type to apply (e.g. 'Blocks', 'Relates', 'Duplicate'). Use jira_getIssueLinkTypes to discover valid names for this JIRA installation."),
+    comment: z.string().optional().describe("Optional comment added to the inward issue when the link is created, in JIRA Wiki Markup.")
+  },
+  unlinkIssues: {
+    linkId: z.string().describe("The id of the issue link to delete. Link ids can be found in the 'issuelinks' field of an issue (retrieve it via jira_getIssue with the 'issuelinks' field).")
   }
 };


### PR DESCRIPTION
## What
Adds three MCP tools to the Jira package:
- `jira_getIssueLinkTypes` — list available link types (Blocks, Relates, …) so callers can discover valid link type names
- `jira_linkIssues` — create a link between two issues (inward/outward key + link type name, with an optional comment on the inward issue)
- `jira_unlinkIssues` — delete an existing link by its id

Also fixes a latent bug in the generated client: endpoints returning a success status with `Content-Type: application/json` but an empty body (e.g. `POST /issueLink`) caused `response.json()` to throw and log a `SyntaxError` to stderr even though the operation succeeded. The client now reads the body as text first and only parses when non-empty.

## Testing
- Unit tests for each new service method and for the empty-body handling (44 passing)
- Verified end-to-end against a live Jira DC instance: created "Relates" links between real issues and removed a throwaway link via unlink — no stderr noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)