### PR TITLE
feat(confluence): allow moving pages via updateContent parentId

### DIFF
--- a/packages/confluence/README.md
+++ b/packages/confluence/README.md
@@ -228,7 +228,7 @@ Parameters:
 - `content` (string, optional): New content body in Confluence Data Center's storage format (XML-based)
 - `version` (number, required): New version number (must be incremented from current version)
 - `versionComment` (string, optional): Comment for this version
-- `parentId` (string, optional): ID of the new parent page (moves the page under this parent; uses Confluence `ancestors`, same as `createContent` `parentId`)
+- `parentId` (string, optional): ID of the new parent page (moves the page under this parent; must be different from `contentId`; uses Confluence `ancestors`, same as `createContent` `parentId`)
 - `output` (`ack` | `full`, optional): Return a compact acknowledgement or the full API response. Defaults to `ack`.
 
 #### 5. confluence_searchSpace

--- a/packages/confluence/README.md
+++ b/packages/confluence/README.md
@@ -228,6 +228,7 @@ Parameters:
 - `content` (string, optional): New content body in Confluence Data Center's storage format (XML-based)
 - `version` (number, required): New version number (must be incremented from current version)
 - `versionComment` (string, optional): Comment for this version
+- `parentId` (string, optional): ID of the new parent page (moves the page under this parent; uses Confluence `ancestors`, same as `createContent` `parentId`)
 - `output` (`ack` | `full`, optional): Return a compact acknowledgement or the full API response. Defaults to `ack`.
 
 #### 5. confluence_searchSpace

--- a/packages/confluence/src/confluence-service.ts
+++ b/packages/confluence/src/confluence-service.ts
@@ -354,6 +354,7 @@ export const confluenceToolSchemas = {
     content: z.string().optional().describe("New content body in Confluence Data Center storage format (XML-based)"),
     version: z.number().describe("New version number (must be incremented)"),
     versionComment: z.string().optional().describe("Comment for this version"),
+    parentId: z.string().optional().describe("ID of the new parent page (moves the page under this parent; same mechanism as createContent parentId)"),
     output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
   },
   searchSpaces: {

--- a/packages/confluence/src/confluence-service.ts
+++ b/packages/confluence/src/confluence-service.ts
@@ -354,7 +354,7 @@ export const confluenceToolSchemas = {
     content: z.string().optional().describe("New content body in Confluence Data Center storage format (XML-based)"),
     version: z.number().describe("New version number (must be incremented)"),
     versionComment: z.string().optional().describe("Comment for this version"),
-    parentId: z.string().optional().describe("ID of the new parent page (moves the page under this parent; same mechanism as createContent parentId)"),
+    parentId: z.string().optional().describe("ID of the new parent page (moves the page under this parent; must be different from contentId; same mechanism as createContent parentId)"),
     output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
   },
   searchSpaces: {

--- a/packages/confluence/src/index.ts
+++ b/packages/confluence/src/index.ts
@@ -89,9 +89,9 @@ server.tool(
 
 server.tool(
   "confluence_updateContent",
-  `Update existing content in ${confluenceInstanceType}`,
+  `Update existing content in ${confluenceInstanceType}. Optionally move the page by setting parentId.`,
   confluenceToolSchemas.updateContent,
-  async ({ contentId, title, content, version, versionComment, output }) => {
+  async ({ contentId, title, content, version, versionComment, parentId, output }) => {
     // First get the current content to build upon
     const currentContent = await confluenceService.getContentRaw(contentId);
 
@@ -128,6 +128,11 @@ server.tool(
           representation: 'storage'
         }
       };
+    }
+
+    // Move page under a new parent when parentId is provided
+    if (parentId) {
+      updateObj.ancestors = [{ id: parentId }];
     }
 
     const result = await confluenceService.updateContent(contentId, updateObj);

--- a/packages/confluence/src/index.ts
+++ b/packages/confluence/src/index.ts
@@ -92,6 +92,14 @@ server.tool(
   `Update existing content in ${confluenceInstanceType}. Optionally move the page by setting parentId.`,
   confluenceToolSchemas.updateContent,
   async ({ contentId, title, content, version, versionComment, parentId, output }) => {
+    // Fail fast on a self-referential move before any API round trip.
+    if (parentId && parentId === contentId) {
+      return formatToolResponse({
+        success: false,
+        error: `parentId (${parentId}) must be different from contentId; a page cannot be its own parent`
+      });
+    }
+
     // First get the current content to build upon
     const currentContent = await confluenceService.getContentRaw(contentId);
 


### PR DESCRIPTION
## Summary
- Add optional `parentId` to `confluence_updateContent` (mirrors `confluence_createContent`).
- When set, the update payload includes `ancestors: [{ id: parentId }]`, which Confluence DC uses to move/reparent a page.
- Document the parameter in the Confluence package README.

## Why
Agents that reorganize Confluence spaces currently cannot move pages through this MCP: create supports `parentId`, but update does not. Workarounds require raw REST calls outside the tool surface.

## Test plan
- [ ] `confluence_updateContent` without `parentId` still updates title/body as before
- [ ] `confluence_updateContent` with `parentId` moves the page under the new parent (verify in Confluence page tree)
- [ ] Move + body/title change in one call works
- [ ] Invalid `parentId` returns a Confluence API error (no crash)