### PR TITLE
feat(bitbucket): add pull request merge tools behind an opt-in gateway

### DIFF
--- a/packages/bitbucket/README.md
+++ b/packages/bitbucket/README.md
@@ -114,6 +114,7 @@ Alternatively, you can use `BITBUCKET_API_BASE_PATH` instead of `BITBUCKET_HOST`
 - Get file contents
 - Browse branches and commits
 - Get pull request information
+- Check pull request mergeability, and merge pull requests when the operator enables it
 - Search and filter repositories
 
 ## Setup
@@ -136,6 +137,33 @@ Alternatively, you can use `BITBUCKET_API_BASE_PATH` instead of `BITBUCKET_HOST`
    ```
 
    See [Configuration sources](#configuration-sources) for the full precedence chain.
+
+   ### Merging pull requests (opt-in)
+
+   Merging lands code on a shared branch and cannot be undone through the API, so `bitbucket_mergePullRequest` is **not even registered** by default. `bitbucket_canMergePullRequest` is always available — it is read-only and only reports what is blocking a merge.
+
+   Merging is opt-in and confined to repositories the operator names; the model cannot choose or widen the scope:
+
+   ```
+   # Enable merging (default: false)
+   BITBUCKET_MERGE_ENABLED=true
+
+   # Required: repositories that may be merged, as "PROJECT/repository-slug".
+   # A "PROJECT/*" entry allows every repository in that project. Comma-separated.
+   BITBUCKET_MERGE_ALLOWED_REPOS=PROJ/demo,SANDBOX/*
+
+   # Optional: restrict which branches may be merged into. A trailing "*" matches a
+   # prefix; bare names are expanded to refs/heads/<name>. Omit to allow any branch
+   # in the allowed repositories.
+   BITBUCKET_MERGE_ALLOWED_TARGET_REFS=develop,refs/heads/release/*
+   ```
+
+   Guardrails applied when enabled:
+   - The tool only activates when the flag is set **and** at least one valid repository entry resolves; otherwise it stays unregistered and a warning is logged. Malformed entries (and a `*/*` catch-all) are rejected individually.
+   - Every request is checked against the allowlist before any API call — repository first, then the pull request's target branch when target refs are restricted.
+   - `version` is a required parameter (optimistic locking). Bitbucket rejects a stale version, so a pull request that changed after you inspected it cannot be merged by accident.
+   - The mergeability check runs before the merge: a conflicted or veto-blocked pull request (missing approvals, unresolved tasks, failed builds) is refused without issuing the write, and the veto reasons are returned.
+   - Auto-merge (queuing a merge until checks pass) is not exposed.
 
    To create a personal access token:
   - In Bitbucket, select your profile picture at the bottom left
@@ -228,8 +256,32 @@ Parameters:
 - `limit` (number, optional): Maximum number of results to return. Defaults to `BITBUCKET_DEFAULT_PAGE_SIZE` or `25`.
 - `start` (number, optional): Starting index for pagination
 
+#### 7. bitbucket_canMergePullRequest
+
+Check whether a pull request can be merged. Read-only — always available.
+
+Parameters:
+- `projectKey` (string, required): The project key
+- `repositorySlug` (string, required): The repository slug
+- `pullRequestId` (string, required): The pull request ID
+
+Returns `canMerge`, `conflicted`, `outcome`, and `vetoes` (each with a `summary` and `detail`) so you can see what is blocking a merge.
+
+#### 8. bitbucket_mergePullRequest
+
+Merge a pull request. Only registered when merging is enabled for the server — see [Merging pull requests (opt-in)](#merging-pull-requests-opt-in).
+
+Parameters:
+- `projectKey` (string, required): The project key
+- `repositorySlug` (string, required): The repository slug
+- `pullRequestId` (string, required): The pull request ID
+- `version` (number, required): The current pull request version, from `bitbucket_getPullRequest`. A stale version is rejected by the server.
+- `strategyId` (string, optional): Merge strategy id, e.g. `no-ff`, `ff`, `ff-only`, `rebase-no-ff`, `rebase-ff-only`, `squash`, `squash-ff-only`. Defaults to the repository's configured strategy.
+- `message` (string, optional): Merge commit message. Defaults to Bitbucket's generated message.
+- `output` (string, optional): `ack` (default) or `full`
+
 ## Response Shaping
 
 - Paginated read tools use `BITBUCKET_DEFAULT_PAGE_SIZE` when `limit` is omitted.
 - `bitbucket_getPR_CommentsAndAction` and `bitbucket_getPullRequestChanges` support `output=summary|compact|full`. The default is `compact`.
-- `bitbucket_postPullRequestComment`, `bitbucket_createPullRequest`, and `bitbucket_updatePullRequest` support `output=ack|full`. The default is `ack`.
+- `bitbucket_postPullRequestComment`, `bitbucket_createPullRequest`, `bitbucket_updatePullRequest`, and `bitbucket_mergePullRequest` support `output=ack|full`. The default is `ack`.

--- a/packages/bitbucket/src/__tests__/merge-gateway.test.ts
+++ b/packages/bitbucket/src/__tests__/merge-gateway.test.ts
@@ -1,0 +1,119 @@
+import {
+  assertRepoMergeAllowed,
+  assertTargetRefMergeAllowed,
+  resolveMergeGateway,
+} from '../merge-gateway.js';
+
+const silentWarn = () => undefined;
+
+describe('resolveMergeGateway', () => {
+  it('is disabled by default', () => {
+    const gateway = resolveMergeGateway({ env: {}, warn: silentWarn });
+    expect(gateway.enabled).toBe(false);
+    expect(gateway.repos).toEqual([]);
+  });
+
+  it('stays disabled when enabled without any repository', () => {
+    const gateway = resolveMergeGateway({ env: { BITBUCKET_MERGE_ENABLED: 'true' }, warn: silentWarn });
+    expect(gateway.enabled).toBe(false);
+  });
+
+  it('stays disabled when every configured repository entry is malformed', () => {
+    const gateway = resolveMergeGateway({
+      env: { BITBUCKET_MERGE_ENABLED: 'true', BITBUCKET_MERGE_ALLOWED_REPOS: 'demo, PROJ/a/b, */*' },
+      warn: silentWarn,
+    });
+    expect(gateway.enabled).toBe(false);
+  });
+
+  it('normalizes repository entries and de-duplicates them', () => {
+    const gateway = resolveMergeGateway({
+      env: {
+        BITBUCKET_MERGE_ENABLED: 'yes',
+        BITBUCKET_MERGE_ALLOWED_REPOS: 'proj/Demo, PROJ/demo; OTHER/*',
+      },
+      warn: silentWarn,
+    });
+    expect(gateway.enabled).toBe(true);
+    expect(gateway.repos).toEqual(['PROJ/demo', 'OTHER/*']);
+    expect(gateway.targetRefs).toEqual([]);
+  });
+
+  it('expands bare branch names into fully-qualified target refs', () => {
+    const gateway = resolveMergeGateway({
+      env: {
+        BITBUCKET_MERGE_ENABLED: '1',
+        BITBUCKET_MERGE_ALLOWED_REPOS: 'PROJ/demo',
+        BITBUCKET_MERGE_ALLOWED_TARGET_REFS: 'develop, refs/heads/release/*',
+      },
+      warn: silentWarn,
+    });
+    expect(gateway.targetRefs).toEqual(['refs/heads/develop', 'refs/heads/release/*']);
+  });
+
+  it('warns about ignored entries and about being enabled with no valid repository', () => {
+    const warnings: string[] = [];
+    resolveMergeGateway({
+      env: { BITBUCKET_MERGE_ENABLED: 'true', BITBUCKET_MERGE_ALLOWED_REPOS: 'demo' },
+      warn: message => warnings.push(message),
+    });
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain('"demo"');
+    expect(warnings[1]).toContain('stay disabled');
+  });
+});
+
+describe('assertRepoMergeAllowed', () => {
+  const gateway = resolveMergeGateway({
+    env: { BITBUCKET_MERGE_ENABLED: 'true', BITBUCKET_MERGE_ALLOWED_REPOS: 'PROJ/demo, OTHER/*' },
+    warn: silentWarn,
+  });
+
+  it('refuses everything when merging is disabled', () => {
+    expect(() => assertRepoMergeAllowed({ enabled: false, repos: [], targetRefs: [] }, 'PROJ', 'demo'))
+      .toThrow(/disabled on this server/);
+  });
+
+  it('allows an exact repository regardless of the casing used by the caller', () => {
+    expect(() => assertRepoMergeAllowed(gateway, 'proj', 'DEMO')).not.toThrow();
+  });
+
+  it('allows any repository in a wildcard project', () => {
+    expect(() => assertRepoMergeAllowed(gateway, 'OTHER', 'anything')).not.toThrow();
+  });
+
+  it('refuses a repository outside the allowed list', () => {
+    expect(() => assertRepoMergeAllowed(gateway, 'PROJ', 'other-repo')).toThrow(/not allowed in PROJ\/other-repo/);
+  });
+
+  it('does not treat a wildcard project as a prefix of another project', () => {
+    expect(() => assertRepoMergeAllowed(gateway, 'OTHERS', 'demo')).toThrow(/not allowed/);
+  });
+});
+
+describe('assertTargetRefMergeAllowed', () => {
+  const unrestricted = { enabled: true, repos: ['PROJ/demo'], targetRefs: [] };
+  const restricted = {
+    enabled: true,
+    repos: ['PROJ/demo'],
+    targetRefs: ['refs/heads/develop', 'refs/heads/release/*'],
+  };
+
+  it('allows any ref when no target-ref restriction is configured', () => {
+    expect(() => assertTargetRefMergeAllowed(unrestricted, 'refs/heads/master')).not.toThrow();
+    expect(() => assertTargetRefMergeAllowed(unrestricted, undefined)).not.toThrow();
+  });
+
+  it('allows an exact and a wildcard target ref', () => {
+    expect(() => assertTargetRefMergeAllowed(restricted, 'refs/heads/develop')).not.toThrow();
+    expect(() => assertTargetRefMergeAllowed(restricted, 'refs/heads/release/1.2')).not.toThrow();
+  });
+
+  it('refuses a target ref outside the allowed list', () => {
+    expect(() => assertTargetRefMergeAllowed(restricted, 'refs/heads/master')).toThrow(/refs\/heads\/master is not allowed/);
+  });
+
+  it('refuses when the target ref is unknown but restrictions apply', () => {
+    expect(() => assertTargetRefMergeAllowed(restricted, undefined)).toThrow(/Could not determine the target branch/);
+  });
+});

--- a/packages/bitbucket/src/__tests__/pr-merge.test.ts
+++ b/packages/bitbucket/src/__tests__/pr-merge.test.ts
@@ -1,0 +1,206 @@
+import { PullRequestsService } from '../bitbucket-client/index.js';
+import { fetchMergeability, mergePullRequest } from '../pr-merge.js';
+import type { MergeGateway } from '../merge-gateway.js';
+
+jest.mock('../bitbucket-client/index.js', () => ({
+  PullRequestsService: {
+    canMerge: jest.fn(),
+    merge: jest.fn(),
+    get3: jest.fn(),
+  },
+  OpenAPI: { BASE: '', TOKEN: '', VERSION: '' },
+}));
+
+const canMerge = PullRequestsService.canMerge as jest.Mock;
+const merge = PullRequestsService.merge as jest.Mock;
+const getPullRequest = PullRequestsService.get3 as jest.Mock;
+
+const OPEN_GATEWAY: MergeGateway = { enabled: true, repos: ['PROJ/demo'], targetRefs: [] };
+const CLEAN = { canMerge: true, conflicted: false, outcome: 'CLEAN', vetoes: [] };
+const MERGED_PR = {
+  id: 42,
+  version: 3,
+  title: 'Add merge tool',
+  state: 'MERGED',
+  fromRef: { id: 'refs/heads/feature' },
+  toRef: { id: 'refs/heads/develop' },
+  reviewers: [],
+};
+
+const baseParams = {
+  projectKey: 'PROJ',
+  repositorySlug: 'demo',
+  pullRequestId: '42',
+  version: 2,
+};
+
+describe('fetchMergeability', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('shapes vetoes into summary/detail pairs', async () => {
+    canMerge.mockResolvedValue({
+      canMerge: false,
+      conflicted: false,
+      outcome: 'VETOED',
+      vetoes: [{ summaryMessage: 'Not enough approvals', detailedMessage: '2 required, 1 given' }],
+    });
+
+    const result = await fetchMergeability('PROJ', 'demo', '42');
+
+    expect(canMerge).toHaveBeenCalledWith('PROJ', '42', 'demo');
+    expect(result.data).toEqual({
+      canMerge: false,
+      conflicted: false,
+      outcome: 'VETOED',
+      vetoes: [{ summary: 'Not enough approvals', detail: '2 required, 1 given' }],
+    });
+  });
+
+  it('reports API failures without shaping', async () => {
+    canMerge.mockRejectedValue(new Error('boom'));
+
+    const result = await fetchMergeability('PROJ', 'demo', '42');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('boom');
+  });
+});
+
+describe('mergePullRequest', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('merges with the version as an optimistic lock and returns a compact ack', async () => {
+    canMerge.mockResolvedValue(CLEAN);
+    merge.mockResolvedValue(MERGED_PR);
+
+    const result = await mergePullRequest({ ...baseParams, gateway: OPEN_GATEWAY });
+
+    expect(merge).toHaveBeenCalledWith('PROJ', '42', 'demo', '2', { version: 2 });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      id: 42,
+      version: 3,
+      title: 'Add merge tool',
+      state: 'MERGED',
+      fromRefId: 'refs/heads/feature',
+      toRefId: 'refs/heads/develop',
+      reviewerCount: 0,
+    });
+  });
+
+  it('passes the strategy and message through, and can return the full payload', async () => {
+    canMerge.mockResolvedValue(CLEAN);
+    merge.mockResolvedValue(MERGED_PR);
+
+    const result = await mergePullRequest({
+      ...baseParams,
+      gateway: OPEN_GATEWAY,
+      strategyId: 'squash',
+      message: 'Squashed',
+      output: 'full',
+    });
+
+    expect(merge).toHaveBeenCalledWith('PROJ', '42', 'demo', '2', {
+      version: 2,
+      strategyId: 'squash',
+      message: 'Squashed',
+    });
+    expect(result.data).toBe(MERGED_PR);
+  });
+
+  it('refuses without any request when merging is disabled', async () => {
+    const result = await mergePullRequest({
+      ...baseParams,
+      gateway: { enabled: false, repos: [], targetRefs: [] },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/disabled on this server/);
+    expect(canMerge).not.toHaveBeenCalled();
+    expect(merge).not.toHaveBeenCalled();
+  });
+
+  it('refuses a repository outside the allowed list without any request', async () => {
+    const result = await mergePullRequest({
+      ...baseParams,
+      repositorySlug: 'other-repo',
+      gateway: OPEN_GATEWAY,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not allowed in PROJ\/other-repo/);
+    expect(merge).not.toHaveBeenCalled();
+  });
+
+  it('refuses a target branch outside the allowed refs and never merges', async () => {
+    getPullRequest.mockResolvedValue({ toRef: { id: 'refs/heads/master' } });
+
+    const result = await mergePullRequest({
+      ...baseParams,
+      gateway: { enabled: true, repos: ['PROJ/demo'], targetRefs: ['refs/heads/develop'] },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/refs\/heads\/master is not allowed/);
+    expect(canMerge).not.toHaveBeenCalled();
+    expect(merge).not.toHaveBeenCalled();
+  });
+
+  it('merges when the pull request targets an allowed branch', async () => {
+    getPullRequest.mockResolvedValue({ toRef: { id: 'refs/heads/release/1.2' } });
+    canMerge.mockResolvedValue(CLEAN);
+    merge.mockResolvedValue(MERGED_PR);
+
+    const result = await mergePullRequest({
+      ...baseParams,
+      gateway: { enabled: true, repos: ['PROJ/demo'], targetRefs: ['refs/heads/release/*'] },
+    });
+
+    expect(result.success).toBe(true);
+    expect(merge).toHaveBeenCalled();
+  });
+
+  it('does not fetch the pull request when target branches are unrestricted', async () => {
+    canMerge.mockResolvedValue(CLEAN);
+    merge.mockResolvedValue(MERGED_PR);
+
+    await mergePullRequest({ ...baseParams, gateway: OPEN_GATEWAY });
+
+    expect(getPullRequest).not.toHaveBeenCalled();
+  });
+
+  it('refuses a conflicted pull request before issuing the merge', async () => {
+    canMerge.mockResolvedValue({ canMerge: false, conflicted: true, outcome: 'CONFLICTED', vetoes: [] });
+
+    const result = await mergePullRequest({ ...baseParams, gateway: OPEN_GATEWAY });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/has conflicts/);
+    expect(merge).not.toHaveBeenCalled();
+  });
+
+  it('refuses a vetoed pull request and reports the veto reasons', async () => {
+    canMerge.mockResolvedValue({
+      canMerge: false,
+      conflicted: false,
+      vetoes: [{ summaryMessage: 'Unresolved tasks', detailedMessage: '1 open task' }],
+    });
+
+    const result = await mergePullRequest({ ...baseParams, gateway: OPEN_GATEWAY });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/merge check vetoed the merge\. Unresolved tasks — 1 open task/);
+    expect(merge).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a server-side merge failure such as a stale version', async () => {
+    canMerge.mockResolvedValue(CLEAN);
+    merge.mockRejectedValue({ status: 409, statusText: 'Conflict', body: { errors: [{ message: 'stale' }] } });
+
+    const result = await mergePullRequest({ ...baseParams, gateway: OPEN_GATEWAY });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Error merging pull request: 409 Conflict');
+    expect(result.details).toEqual({ errors: [{ message: 'stale' }] });
+  });
+});

--- a/packages/bitbucket/src/bitbucket-response-mapper.ts
+++ b/packages/bitbucket/src/bitbucket-response-mapper.ts
@@ -100,6 +100,29 @@ export function shapePullRequestAck(pullRequest: any): Record<string, any> {
   };
 }
 
+export interface MergeVeto {
+  summary?: string;
+  detail?: string;
+}
+
+export function shapeMergeability(mergeability: any): {
+  canMerge: boolean;
+  conflicted: boolean;
+  outcome?: string;
+  vetoes: MergeVeto[];
+} {
+  const vetoes = Array.isArray(mergeability?.vetoes) ? mergeability.vetoes : [];
+  return {
+    canMerge: mergeability?.canMerge === true,
+    conflicted: mergeability?.conflicted === true,
+    ...(typeof mergeability?.outcome === 'string' ? { outcome: mergeability.outcome } : {}),
+    vetoes: vetoes.map((veto: any) => ({
+      ...(typeof veto?.summaryMessage === 'string' ? { summary: veto.summaryMessage } : {}),
+      ...(typeof veto?.detailedMessage === 'string' ? { detail: veto.detailedMessage } : {}),
+    })),
+  };
+}
+
 export function shapePullRequestCommentAck(comment: any): Record<string, any> {
   const link = getLink(comment?.links);
   return {

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -4,6 +4,7 @@ import { request as __request } from './bitbucket-client/core/request.js';
 import { handleApiOperation, resolveOpenApiBase } from '@atlassian-dc-mcp/common';
 import { simplifyInboxPullRequests } from './inbox-pr-mapper.js';
 import { BITBUCKET_PRODUCT, getDefaultPageSize, getMissingConfig } from './config.js';
+import { fetchMergeability, mergePullRequest, type MergePullRequestParams } from './pr-merge.js';
 import {
   BitbucketMutationOutputMode,
   BitbucketOutputMode,
@@ -520,6 +521,36 @@ export class BitbucketService {
     }
 
     return result;
+  }
+
+  /**
+   * Check whether a pull request can be merged. Read-only: reports conflicts and any
+   * merge-check vetoes without changing anything.
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param pullRequestId The pull request ID
+   * @returns Promise with the mergeability status
+   */
+  async getPullRequestMergeability(projectKey: string, repositorySlug: string, pullRequestId: string) {
+    return fetchMergeability(projectKey.toUpperCase(), repositorySlug.toLowerCase(), pullRequestId);
+  }
+
+  /**
+   * Merge a pull request. Only permitted for repositories (and target branches) the operator
+   * allowed through the merge gateway; see merge-gateway.ts. A conflicted or vetoed pull
+   * request is refused before the merge request is sent.
+   * @param params.version The current pull request version, required for optimistic locking
+   * @param params.strategyId Optional merge strategy id (e.g. 'no-ff', 'squash', 'ff')
+   * @param params.message Optional merge commit message
+   * @param params.gateway The resolved operator merge policy
+   * @returns Promise with the merged pull request
+   */
+  async mergePullRequest(params: MergePullRequestParams) {
+    return mergePullRequest({
+      ...params,
+      projectKey: params.projectKey.toUpperCase(),
+      repositorySlug: params.repositorySlug.toLowerCase(),
+    });
   }
 
   /**
@@ -1083,6 +1114,20 @@ export const bitbucketToolSchemas = {
     description: z.string().optional().describe("The new description for the pull request"),
     draft: z.boolean().optional().describe("If provided, sets the draft (work-in-progress) status of the pull request. Pass true to mark as draft, false to mark as ready for review."),
     reviewers: z.array(z.string()).optional().describe("Optional array of reviewer usernames to set (use the 'name' field from Bitbucket user objects, not 'slug')"),
+    output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
+  },
+  canMergePullRequest: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID")
+  },
+  mergePullRequest: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    pullRequestId: z.string().describe("The pull request ID"),
+    version: z.number().describe("The current version of the pull request (required for optimistic locking). Fetch it with bitbucket_getPullRequest immediately before merging — the server rejects a stale version, which is what stops a merge of code you have not seen."),
+    strategyId: z.string().optional().describe("Merge strategy id, e.g. 'no-ff', 'ff', 'ff-only', 'rebase-no-ff', 'rebase-ff-only', 'squash', 'squash-ff-only'. Omit to use the strategy configured for the repository."),
+    message: z.string().optional().describe("Commit message for the merge commit. Omit to let Bitbucket generate it."),
     output: z.enum(['ack', 'full']).optional().describe("Return a compact acknowledgement or the full API response. Defaults to ack.")
   },
   getRequiredReviewers: {

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -1,6 +1,7 @@
 import { connectServer, createMcpServer, formatToolResponse, initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService, bitbucketToolSchemas } from './bitbucket-service.js';
 import { getBitbucketRuntimeConfig, getDefaultPageSize } from './config.js';
+import { resolveMergeGateway } from './merge-gateway.js';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
@@ -187,6 +188,44 @@ server.tool(
     return formatToolResponse(result);
   }
 );
+
+server.tool(
+  "bitbucket_canMergePullRequest",
+  "Check whether a pull request can be merged. Read-only: returns canMerge, whether the pull request is conflicted, and any merge-check vetoes (e.g. missing approvals, unresolved tasks, failed builds). Use this before bitbucket_mergePullRequest to see what is blocking a merge.",
+  bitbucketToolSchemas.canMergePullRequest,
+  async ({ projectKey, repositorySlug, pullRequestId }) => {
+    const result = await bitbucketService.getPullRequestMergeability(projectKey, repositorySlug, pullRequestId);
+    return formatToolResponse(result);
+  }
+);
+
+const mergeGateway = resolveMergeGateway();
+
+// Merging lands code on a shared branch and cannot be undone through the API, so the tool is
+// only registered when the operator has explicitly enabled it for specific repositories.
+if (mergeGateway.enabled) {
+  const scope = `Allowed on this server: ${mergeGateway.repos.join(', ')}`
+    + (mergeGateway.targetRefs.length > 0 ? `; target branches: ${mergeGateway.targetRefs.join(', ')}` : '')
+    + '.';
+  server.tool(
+    "bitbucket_mergePullRequest",
+    `Merge a pull request. IMPORTANT: you MUST first call bitbucket_getPullRequest to get the current 'version' — it is required for optimistic locking and a stale version is rejected. The merge is refused if the pull request is conflicted or a merge check vetoes it; use bitbucket_canMergePullRequest to inspect blockers first. This operation is not reversible through the API. ${scope}`,
+    bitbucketToolSchemas.mergePullRequest,
+    async ({ projectKey, repositorySlug, pullRequestId, version, strategyId, message, output }) => {
+      const result = await bitbucketService.mergePullRequest({
+        projectKey,
+        repositorySlug,
+        pullRequestId,
+        version,
+        strategyId,
+        message,
+        output,
+        gateway: mergeGateway,
+      });
+      return formatToolResponse(result);
+    }
+  );
+}
 
 server.tool(
   "bitbucket_getRequiredReviewers",

--- a/packages/bitbucket/src/merge-gateway.ts
+++ b/packages/bitbucket/src/merge-gateway.ts
@@ -1,0 +1,132 @@
+/**
+ * Operator-controlled gate for merging pull requests.
+ *
+ * A merge writes to a shared branch and cannot be undone through the API, so it is
+ * disabled by default: `bitbucket_mergePullRequest` is not even registered unless the
+ * operator enables it and names the repositories it may merge in. The allowed scope is
+ * read from the environment once at startup, so the model can never select or widen it.
+ * Read-only mergeability checks are not gated.
+ */
+export interface MergeGateway {
+  /** Whether merging is enabled and at least one valid repository pattern resolved. */
+  enabled: boolean;
+  /** Allowed `PROJECT/repository-slug` targets; a `PROJECT/*` entry allows the whole project. */
+  repos: string[];
+  /** Allowed target refs; a trailing `*` matches a prefix. Empty means any ref in an allowed repository. */
+  targetRefs: string[];
+}
+
+type Env = Record<string, string | undefined>;
+type Warn = (message: string) => void;
+
+const DISABLED: MergeGateway = { enabled: false, repos: [], targetRefs: [] };
+
+const REPO_ENTRY_RE = /^[^\s/]+\/[^\s/]+$/;
+
+function readBool(env: Env, name: string): boolean {
+  const value = env[name]?.trim().toLowerCase();
+  return value === 'true' || value === '1' || value === 'yes';
+}
+
+function parseList(raw: string | undefined): string[] {
+  return (raw ?? '').split(/[,;\s]+/).map(entry => entry.trim()).filter(Boolean);
+}
+
+function dedupe(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+/**
+ * Accepts `PROJECT/repository-slug` or `PROJECT/*`. The project key is upper-cased and
+ * the slug lower-cased to match the casing the REST API uses, so comparisons are exact.
+ */
+function normalizeRepoEntry(entry: string, warn: Warn): string | undefined {
+  if (!REPO_ENTRY_RE.test(entry)) {
+    warn(`Ignoring merge repository entry that is not "PROJECT/repository-slug" or "PROJECT/*": "${entry}"`);
+    return undefined;
+  }
+  const [projectKey, slug] = entry.split('/');
+  if (projectKey === '*') {
+    warn(`Ignoring merge repository entry that would allow every project: "${entry}"`);
+    return undefined;
+  }
+  return `${projectKey.toUpperCase()}/${slug.toLowerCase()}`;
+}
+
+/** Bare branch names are expanded so operators can write `develop` instead of `refs/heads/develop`. */
+function normalizeRefEntry(entry: string): string {
+  return entry.startsWith('refs/') ? entry : `refs/heads/${entry}`;
+}
+
+function matchesPattern(value: string, pattern: string): boolean {
+  return pattern.endsWith('*') ? value.startsWith(pattern.slice(0, -1)) : value === pattern;
+}
+
+/**
+ * Reads the merge gateway configuration from the environment. Merging only activates
+ * when the flag is set and at least one repository entry is valid; otherwise a warning
+ * is logged and the gateway stays disabled.
+ */
+export function resolveMergeGateway(options?: { env?: Env; warn?: Warn }): MergeGateway {
+  const env = options?.env ?? process.env;
+  const warn = options?.warn ?? ((message: string) => console.error(`[merge-gateway] ${message}`));
+
+  if (!readBool(env, 'BITBUCKET_MERGE_ENABLED')) {
+    return DISABLED;
+  }
+
+  const repos = dedupe(
+    parseList(env.BITBUCKET_MERGE_ALLOWED_REPOS)
+      .map(entry => normalizeRepoEntry(entry, warn))
+      .filter((entry): entry is string => Boolean(entry)),
+  );
+
+  if (repos.length === 0) {
+    warn(
+      'Merging was enabled but no valid repository is configured (set BITBUCKET_MERGE_ALLOWED_REPOS ' +
+        'to a list of "PROJECT/repository-slug" or "PROJECT/*" entries); the merge tool will stay disabled.',
+    );
+    return DISABLED;
+  }
+
+  return {
+    enabled: true,
+    repos,
+    targetRefs: dedupe(parseList(env.BITBUCKET_MERGE_ALLOWED_TARGET_REFS).map(normalizeRefEntry)),
+  };
+}
+
+/** Throws unless the gateway allows merging in this repository. No network call. */
+export function assertRepoMergeAllowed(gateway: MergeGateway, projectKey: string, repositorySlug: string): void {
+  if (!gateway.enabled) {
+    throw new Error(
+      'Merging pull requests is disabled on this server. Enable it with BITBUCKET_MERGE_ENABLED ' +
+        'and list the allowed repositories in BITBUCKET_MERGE_ALLOWED_REPOS.',
+    );
+  }
+  const target = `${projectKey.toUpperCase()}/${repositorySlug.toLowerCase()}`;
+  if (!gateway.repos.some(pattern => matchesPattern(target, pattern))) {
+    throw new Error(
+      `Merging is not allowed in ${target} on this server. Allowed: ${gateway.repos.join(', ')}.`,
+    );
+  }
+}
+
+/** Throws unless the gateway allows merging into this target ref. A gateway with no ref restriction allows all. */
+export function assertTargetRefMergeAllowed(gateway: MergeGateway, targetRefId: string | undefined): void {
+  if (gateway.targetRefs.length === 0) {
+    return;
+  }
+  if (!targetRefId) {
+    throw new Error(
+      'Could not determine the target branch of the pull request, and this server restricts which ' +
+        'branches may be merged into (BITBUCKET_MERGE_ALLOWED_TARGET_REFS); refusing to merge.',
+    );
+  }
+  if (!gateway.targetRefs.some(pattern => matchesPattern(targetRefId, pattern))) {
+    throw new Error(
+      `Merging into ${targetRefId} is not allowed on this server. ` +
+        `Allowed target refs: ${gateway.targetRefs.join(', ')}.`,
+    );
+  }
+}

--- a/packages/bitbucket/src/pr-merge.ts
+++ b/packages/bitbucket/src/pr-merge.ts
@@ -1,0 +1,94 @@
+import { handleApiOperation } from '@atlassian-dc-mcp/common';
+import { PullRequestsService } from './bitbucket-client/index.js';
+import {
+  BitbucketMutationOutputMode,
+  shapeMergeability,
+  shapePullRequestAck,
+} from './bitbucket-response-mapper.js';
+import { assertRepoMergeAllowed, assertTargetRefMergeAllowed, type MergeGateway } from './merge-gateway.js';
+
+export interface MergePullRequestParams {
+  projectKey: string;
+  repositorySlug: string;
+  pullRequestId: string;
+  /** Current PR version, required for optimistic locking. */
+  version: number;
+  gateway: MergeGateway;
+  strategyId?: string;
+  message?: string;
+  output?: BitbucketMutationOutputMode;
+}
+
+/** Read-only mergeability check: reports conflicts and merge-check vetoes. */
+export async function fetchMergeability(projectKey: string, repositorySlug: string, pullRequestId: string) {
+  const result = await handleApiOperation(
+    () => PullRequestsService.canMerge(projectKey, pullRequestId, repositorySlug),
+    'Error checking pull request mergeability',
+  );
+
+  if (result.success && result.data) {
+    return { ...result, data: shapeMergeability(result.data) };
+  }
+
+  return result;
+}
+
+function describeVetoes(vetoes: Array<{ summary?: string; detail?: string }>): string {
+  return vetoes
+    .map(veto => [veto.summary, veto.detail].filter(Boolean).join(' — '))
+    .filter(Boolean)
+    .join('; ');
+}
+
+async function assertMergeable(projectKey: string, repositorySlug: string, pullRequestId: string): Promise<void> {
+  const mergeability = shapeMergeability(
+    await PullRequestsService.canMerge(projectKey, pullRequestId, repositorySlug),
+  );
+  if (mergeability.canMerge) {
+    return;
+  }
+  const cause = mergeability.conflicted ? 'it has conflicts' : 'a merge check vetoed the merge';
+  const reasons = describeVetoes(mergeability.vetoes);
+  throw new Error(`Pull request cannot be merged: ${cause}${reasons ? `. ${reasons}` : ''}`);
+}
+
+/** Only fetches the pull request when the operator restricts target branches. */
+async function assertTargetRefAllowed(params: MergePullRequestParams): Promise<void> {
+  if (params.gateway.targetRefs.length === 0) {
+    return;
+  }
+  const pullRequest: any = await PullRequestsService.get3(
+    params.projectKey,
+    params.pullRequestId,
+    params.repositorySlug,
+  );
+  assertTargetRefMergeAllowed(params.gateway, pullRequest?.toRef?.id);
+}
+
+/**
+ * Merge a pull request under the operator's merge policy. Order matters: the repository
+ * (and target branch, when restricted) is checked before any request, and the mergeability
+ * check runs before the POST so a conflicted or vetoed pull request is refused without
+ * issuing the write.
+ */
+export async function mergePullRequest(params: MergePullRequestParams) {
+  const { projectKey, repositorySlug, pullRequestId, version, gateway } = params;
+
+  const result = await handleApiOperation(async () => {
+    assertRepoMergeAllowed(gateway, projectKey, repositorySlug);
+    await assertTargetRefAllowed(params);
+    await assertMergeable(projectKey, repositorySlug, pullRequestId);
+
+    return PullRequestsService.merge(projectKey, pullRequestId, repositorySlug, String(version), {
+      version,
+      ...(params.strategyId ? { strategyId: params.strategyId } : {}),
+      ...(params.message ? { message: params.message } : {}),
+    });
+  }, 'Error merging pull request');
+
+  if (result.success && result.data && params.output !== 'full') {
+    return { ...result, data: shapePullRequestAck(result.data) };
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Why

For people who automate their day-to-day work, this closes the last gap in the PR workflow.

Today an agent can do almost the whole review cycle through this MCP — find the PR, read the diff and changes, post inline comments and tasks, submit a review, update the PR — and then has to stop and hand the user back to the Bitbucket UI for the one remaining click. That context switch is exactly the kind of interruption automation is meant to remove, and it's the step most likely to be forgotten after a long agent-driven session.

With these tools the whole loop stays in the IDE: check what's blocking the merge, fix it, merge. No browser tab, no re-finding the PR, no leaving the editor.

## What's added

- **`bitbucket_canMergePullRequest`** — read-only mergeability check, always available. Returns `canMerge`, `conflicted`, `outcome`, and `vetoes` (shaped into `summary`/`detail`), so blockers like missing approvals, unresolved tasks, or failed builds are visible and actionable rather than a wall of API JSON.
- **`bitbucket_mergePullRequest`** — merges a PR. Takes the current `version` (optimistic locking), and optionally `strategyId` (`no-ff`, `squash`, `ff`, …) and a merge commit `message`. Supports `output=ack|full` like the other mutation tools, defaulting to a compact ack.

Auto-merge (queuing a merge until checks pass) is deliberately **not** exposed — it's a scheduled write with no obvious point of user review, and it isn't needed for the IDE workflow above.

## Guardrails — nothing changes for users who don't want this

Merging lands code on a shared branch and cannot be undone through the API, so it follows the same opt-in model as the attachment filesystem gateway rather than shipping on by default. The read-only mergeability check is unaffected: it's a plain API read and stays always available.

**If you do nothing, nothing changes.** `bitbucket_mergePullRequest` is not registered at all — it doesn't appear in `tools/list`, so the model cannot see it, let alone call it.

Enabling it is explicit and operator-scoped:

```
# Off by default
BITBUCKET_MERGE_ENABLED=true

# Required: repositories that may be merged. "PROJECT/*" allows a whole project.
BITBUCKET_MERGE_ALLOWED_REPOS=PROJ/demo,SANDBOX/*

# Optional: restrict which branches may be merged into. Trailing "*" matches a
# prefix; bare names expand to refs/heads/<name>. Omit to allow any branch in
# the allowed repositories.
BITBUCKET_MERGE_ALLOWED_TARGET_REFS=develop,refs/heads/release/*
```

Applied guardrails:

- **Not registered unless enabled** — and enabling the flag alone is not enough: without at least one valid repository entry the tool stays unregistered and a warning is logged. Malformed entries and a `*/*` catch-all are rejected individually.
- **The scope is operator-owned and the model cannot widen it.** Repositories and target branches are read from the environment once at startup — they are never tool parameters. The registered tool's description states the allowed scope, so the model works within the boundary instead of discovering it by failing.
- **Policy is checked before any side effect.** Repository allowlist first (no network call), then the PR's *real* target ref read back from the server — not a value the model supplied — and only when target refs are actually restricted.
- **A blocked PR is refused without issuing the write.** The mergeability check runs first, so a conflicted or veto-blocked PR never reaches the merge endpoint, and the veto reasons are returned instead.
- **`version` is required** (optimistic locking). Bitbucket rejects a stale version, so a PR that changed after it was inspected cannot be merged by accident.
- Merging remains subject to everything Bitbucket already enforces server-side: `REPO_WRITE` permission on the token, branch permissions, and merge checks.

## Tests & verification

- New: `merge-gateway.test.ts` (env parsing, normalization, allowlist matching including the wildcard-prefix edge case, refusal messages) and `pr-merge.test.ts` (merge call shape, ack/full output, refusal paths, and assertions that no write is issued when a check fails).
- Full suite green: 374 tests across the four packages, `npm run build` clean.
- Verified end-to-end against the built server over stdio via `tools/list`: absent by default; absent with a warning when enabled but unconfigured; registered with the allowed scope in its description once configured.

## Docs

`packages/bitbucket/README.md` gains a "Merging pull requests (opt-in)" section with the env vars and the guardrail list, tool parameter docs, and the response-shaping note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
