### PR TITLE
feat(jira): add tool to update issue comments

### DIFF
--- a/packages/jira/README.md
+++ b/packages/jira/README.md
@@ -114,7 +114,7 @@ Alternatively, you can use `JIRA_API_BASE_PATH` instead of `JIRA_HOST` to specif
 - Get issue details by key
 - Get issue comments
 - Create and update issues
-- Add comments to issues
+- Add and update comments on issues
 - Link and unlink issues
 
 ## Setup
@@ -264,14 +264,23 @@ Parameters:
 - `issueKey` (string, required): The issue key (e.g., "PROJECT-123")
 - `comment` (string, required): Comment text in format suitable for JIRA Data Center edition (JIRA Wiki Markup)
 
-#### 7. jira_getTransitions
+#### 7. jira_updateIssueComment
+
+Update the body of an existing comment on a JIRA issue in the JIRA Data Center edition instance. Use `jira_getIssueComments` to find the comment id.
+
+Parameters:
+- `issueKey` (string, required): The issue key (e.g., "PROJECT-123")
+- `commentId` (string, required): The id of the comment to update (found via `jira_getIssueComments`)
+- `comment` (string, required): New comment text that replaces the existing body, in format suitable for JIRA Data Center edition (JIRA Wiki Markup)
+
+#### 8. jira_getTransitions
 
 Get the available workflow transitions for a JIRA issue in the JIRA Data Center edition instance.
 
 Parameters:
 - `issueKey` (string, required): The issue key (e.g., "PROJECT-123")
 
-#### 8. jira_transitionIssue
+#### 9. jira_transitionIssue
 
 Transition a JIRA issue to a new status in the JIRA Data Center edition instance.
 
@@ -280,13 +289,13 @@ Parameters:
 - `transitionId` (string, required): Transition ID returned by `jira_getTransitions`
 - `fields` (object, optional): Additional fields required by the transition screen
 
-#### 9. jira_getIssueLinkTypes
+#### 10. jira_getIssueLinkTypes
 
 Get the list of available issue link types (e.g., "Blocks", "Relates", "Duplicate") in the JIRA Data Center edition instance. Use this to discover valid link type names before calling `jira_linkIssues`.
 
 Parameters: none
 
-#### 10. jira_linkIssues
+#### 11. jira_linkIssues
 
 Create a link between two JIRA issues in the JIRA Data Center edition instance.
 
@@ -296,14 +305,14 @@ Parameters:
 - `linkType` (string, required): Name of the issue link type to apply (e.g., "Blocks", "Relates"). Use `jira_getIssueLinkTypes` to discover valid names for this JIRA installation.
 - `comment` (string, optional): Comment added to the inward issue when the link is created, in JIRA Wiki Markup
 
-#### 11. jira_unlinkIssues
+#### 12. jira_unlinkIssues
 
 Delete an existing link between two JIRA issues in the JIRA Data Center edition instance.
 
 Parameters:
 - `linkId` (string, required): The id of the issue link to delete. Link ids are found in the `issuelinks` field of an issue (retrieve it via `jira_getIssue` with the `issuelinks` field).
 
-#### 12. jira_uploadAttachment
+#### 13. jira_uploadAttachment
 
 Upload a local file as an attachment to a JIRA issue. Only registered when filesystem uploads are enabled (see [Attachment filesystem access](#attachment-filesystem-access-opt-in)).
 
@@ -312,7 +321,7 @@ Parameters:
 - `sourcePath` (string, required): Path to the file to upload, **relative to a server-configured upload directory**. Absolute paths and `..` segments are rejected; symlinks and non-regular files are refused.
 - `filename` (string, optional): Override for the attachment filename (defaults to the basename of `sourcePath`)
 
-#### 13. jira_downloadAttachment
+#### 14. jira_downloadAttachment
 
 Download attachment(s) from a JIRA issue, by issue key (optionally filtered by filename) or by a single attachment id. Returns the file content inline (base64 or text) — useful for inspecting a file or moving it elsewhere (e.g. re-uploading to a Confluence page). When filesystem downloads are enabled (see [Attachment filesystem access](#attachment-filesystem-access-opt-in)), it can also save into the server-configured download directory.
 

--- a/packages/jira/src/__tests__/jira-service.test.ts
+++ b/packages/jira/src/__tests__/jira-service.test.ts
@@ -19,6 +19,7 @@ jest.mock('../jira-client/index.js', () => ({
     createIssue: jest.fn(),
     getComments: jest.fn(),
     addComment: jest.fn(),
+    updateComment: jest.fn(),
   },
   SearchService: {
     searchUsingSearchRequest: jest.fn(),
@@ -194,6 +195,28 @@ describe('JiraService', () => {
       await jiraService.getIssueComments(mockIssueKey, 'renderedBody', 10, 20);
 
       expect(IssueService.getComments).toHaveBeenCalledWith(mockIssueKey, 'renderedBody', '10', undefined, '20');
+    });
+  });
+
+  describe('updateIssueComment', () => {
+    it('sends the new body to the addressed comment', async () => {
+      const mockComment = { id: '10500', body: 'Updated body' };
+      (IssueService.updateComment as jest.Mock).mockResolvedValue(mockComment);
+
+      const result = await jiraService.updateIssueComment(mockIssueKey, '10500', 'Updated body');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockComment);
+      expect(IssueService.updateComment).toHaveBeenCalledWith(mockIssueKey, '10500', undefined, { body: 'Updated body' });
+    });
+
+    it('surfaces update errors gracefully', async () => {
+      (IssueService.updateComment as jest.Mock).mockRejectedValue(new Error('You do not have permission to edit this comment'));
+
+      const result = await jiraService.updateIssueComment(mockIssueKey, '10500', 'Updated body');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('You do not have permission to edit this comment');
     });
   });
 

--- a/packages/jira/src/index.ts
+++ b/packages/jira/src/index.ts
@@ -88,6 +88,16 @@ server.tool(
 )
 
 server.tool(
+  "jira_updateIssueComment",
+  `Update the body of an existing comment on a JIRA issue in the ${jiraInstanceType}. Use jira_getIssueComments to find the comment id.`,
+  jiraToolSchemas.updateIssueComment,
+  async ({ issueKey, commentId, comment }) => {
+    const result = await jiraService.updateIssueComment(issueKey, commentId, comment);
+    return formatToolResponse(result);
+  }
+)
+
+server.tool(
   "jira_getTransitions",
   `Get available status transitions for a JIRA issue in the ${jiraInstanceType}. Returns a list of transitions with their IDs, names, and target statuses.`,
   jiraToolSchemas.getTransitions,

--- a/packages/jira/src/jira-service.ts
+++ b/packages/jira/src/jira-service.ts
@@ -90,6 +90,13 @@ export class JiraService {
     return handleApiOperation(() => IssueService.addComment(issueKey, undefined, { body: comment }), 'Error posting issue comment');
   }
 
+  async updateIssueComment(issueKey: string, commentId: string, comment: string) {
+    return handleApiOperation(
+      () => IssueService.updateComment(issueKey, commentId, undefined, { body: comment }),
+      'Error updating issue comment'
+    );
+  }
+
   async createIssue(params: {
     projectId: string;
     summary: string;
@@ -350,6 +357,11 @@ export const jiraToolSchemas = {
   postIssueComment: {
     issueKey: z.string().describe("JIRA issue key (e.g., PROJ-123)"),
     comment: z.string().describe("Comment text in the format suitable for JIRA DATA CENTER edition (JIRA Wiki Markup).")
+  },
+  updateIssueComment: {
+    issueKey: z.string().describe("JIRA issue key (e.g., PROJ-123)"),
+    commentId: z.string().describe("The id of the comment to update. Comment ids can be found via jira_getIssueComments."),
+    comment: z.string().describe("New comment text that replaces the existing body, in the format suitable for JIRA DATA CENTER edition (JIRA Wiki Markup).")
   },
   createIssue: {
     projectId: z.string().describe("Project key (despite the parameter name, e.g. TEST)"),


### PR DESCRIPTION
## What

Adds a new Jira MCP tool, **`jira_updateIssueComment`**, that edits the body of an existing comment on a Jira issue. Until now the server could read comments (`jira_getIssueComments`) and post new ones (`jira_postIssueComment`), but there was no way to edit one.

## Why

Editing an existing comment is a common follow-up to posting one (fixing a typo, updating status text an agent left earlier) and previously required dropping out of the MCP server entirely. The underlying capability already existed in the generated client — `IssueService.updateComment` wraps `PUT /rest/api/2/issue/{issueIdOrKey}/comment/{id}` — it just wasn't exposed as a tool.

## Changes

- **`jira-service.ts`** — new `JiraService.updateIssueComment(issueKey, commentId, comment)` method, mirroring `postIssueComment` and routing through `handleApiOperation`.
- **`jira-service.ts`** — `updateIssueComment` Zod schema (`issueKey`, `commentId`, `comment`).
- **`index.ts`** — registers the `jira_updateIssueComment` tool, placed right after `jira_postIssueComment`.
- **`__tests__/jira-service.test.ts`** — unit tests for the success path (correct args forwarded to `IssueService.updateComment`) and the error path (API failure surfaced via the standard result shape).
- **`README.md`** — documents the new tool (renumbered the tool list) and updates the feature list.

## Notes

- This is a pure API operation (a single authenticated `PUT`), the same class as the existing `jira_postIssueComment`, so it needs no attachment-style filesystem gateway or opt-in gate.
- Jira enforces its own comment-edit permissions; a lack of permission is returned to the caller as a normal error result.

## Testing

- `npm run build --workspace=@atlassian-dc-mcp/jira` — compiles cleanly.
- `npm run test --workspace=@atlassian-dc-mcp/jira` — **55 passed** (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
