### PR TITLE
fix(jira): document jira_linkIssues direction against the Jira UI

### DIFF
--- a/packages/jira/README.md
+++ b/packages/jira/README.md
@@ -290,9 +290,11 @@ Parameters: none
 
 Create a link between two JIRA issues in the JIRA Data Center edition instance.
 
+Jira UI labels follow GET `issuelinks`, not the REST POST field names: if GET of an issue contains `outwardIssue`, that issue shows the **outward** phrase (`blocks`); if it contains `inwardIssue`, it shows the **inward** phrase (`is blocked by`). So `inwardIssueKey` is the issue that will display the outward phrase.
+
 Parameters:
-- `inwardIssueKey` (string, required): Key of the inward issue — the one the inward link description applies to (e.g., the issue that "is blocked by"). Example: "PROJECT-123"
-- `outwardIssueKey` (string, required): Key of the outward issue — the one the outward link description applies to (e.g., the issue that "blocks"). Example: "PROJECT-456"
+- `inwardIssueKey` (string, required): REST inward issue. In the Jira UI **this** issue shows the **outward** phrase (e.g. "blocks", "split to"). For PROJECT-123 to show "blocks PROJECT-456", pass `inwardIssueKey=PROJECT-123`.
+- `outwardIssueKey` (string, required): REST outward issue. In the Jira UI **this** issue shows the **inward** phrase (e.g. "is blocked by", "split from"). Same example: `outwardIssueKey=PROJECT-456`.
 - `linkType` (string, required): Name of the issue link type to apply (e.g., "Blocks", "Relates"). Use `jira_getIssueLinkTypes` to discover valid names for this JIRA installation.
 - `comment` (string, optional): Comment added to the inward issue when the link is created, in JIRA Wiki Markup
 

--- a/packages/jira/src/__tests__/jira-service.test.ts
+++ b/packages/jira/src/__tests__/jira-service.test.ts
@@ -463,6 +463,8 @@ describe('JiraService', () => {
     it('should create a link between two issues', async () => {
       (IssueLinkService.linkIssues as jest.Mock).mockResolvedValue(undefined);
 
+      // POST maps keys 1:1 onto inwardIssue/outwardIssue. Do not swap here;
+      // Jira UI labels are documented on the jira_linkIssues tool schema.
       const result = await jiraService.linkIssues({
         inwardIssueKey: 'PROJ-123',
         outwardIssueKey: 'PROJ-456',

--- a/packages/jira/src/index.ts
+++ b/packages/jira/src/index.ts
@@ -129,7 +129,7 @@ server.tool(
 
 server.tool(
   "jira_linkIssues",
-  `Create a link between two JIRA issues in the ${jiraInstanceType}. Use jira_getIssueLinkTypes to find valid link type names.`,
+  `Create a link between two JIRA issues in the ${jiraInstanceType}. Direction is easy to invert vs the Jira UI: inwardIssueKey is the issue that DISPLAYS the outward phrase (e.g. 'blocks'); outwardIssueKey displays the inward phrase (e.g. 'is blocked by'). After create, GET the first issue — it must have outwardIssue = the second key. Use jira_getIssueLinkTypes for valid type names.`,
   jiraToolSchemas.linkIssues,
   async (params) => {
     const result = await jiraService.linkIssues(params);

--- a/packages/jira/src/jira-service.ts
+++ b/packages/jira/src/jira-service.ts
@@ -397,8 +397,8 @@ export const jiraToolSchemas = {
   },
   getIssueLinkTypes: {},
   linkIssues: {
-    inwardIssueKey: z.string().describe("Key of the inward issue (the one the inward link description applies to, e.g. the issue that 'is blocked by'). Example: PROJ-123"),
-    outwardIssueKey: z.string().describe("Key of the outward issue (the one the outward link description applies to, e.g. the issue that 'blocks'). Example: PROJ-456"),
+    inwardIssueKey: z.string().describe("REST inward issue. In Jira UI THIS issue shows the OUTWARD phrase (e.g. 'blocks', 'split to'). For PROJ-123 to show 'blocks PROJ-456', pass inwardIssueKey=PROJ-123."),
+    outwardIssueKey: z.string().describe("REST outward issue. In Jira UI THIS issue shows the INWARD phrase (e.g. 'is blocked by', 'split from'). Same example: outwardIssueKey=PROJ-456."),
     linkType: z.string().describe("Name of the issue link type to apply (e.g. 'Blocks', 'Relates', 'Duplicate'). Use jira_getIssueLinkTypes to discover valid names for this JIRA installation."),
     comment: z.string().optional().describe("Optional comment added to the inward issue when the link is created, in JIRA Wiki Markup.")
   },


### PR DESCRIPTION
## Summary
- `jira_linkIssues` previously described `inwardIssueKey` as the issue that "is blocked by". Agents following that text invert Blocks / Issue split in the Jira UI.
- GET `issuelinks` labels **this** issue with `type.inward` when `inwardIssue` is present, and `type.outward` when `outwardIssue` is present ([issue linking model](https://developer.atlassian.com/cloud/jira/platform/issue-linking-model/)).
- POST mapping stays 1:1 (`inwardIssueKey` → `inwardIssue`). Schema, tool description, README, and a test comment now match the UI.

Example: for PROJECT-123 to show "blocks PROJECT-456", pass `inwardIssueKey=PROJECT-123` and `outwardIssueKey=PROJECT-456`.

## Test plan
- [ ] `jira_getIssueLinkTypes` then `jira_linkIssues` with Blocks as above
- [ ] GET PROJECT-123 `issuelinks` contains `outwardIssue: PROJECT-456`
- [ ] Jira UI on PROJECT-123 shows the outward phrase toward PROJECT-456
- [ ] Existing `linkIssues` unit tests still pass (payload not swapped)


Made with [Cursor](https://cursor.com)