### PR TITLE
feat(bitbucket): implement bitbucket_getFileContent (closes #37)

### DIFF
--- a/packages/bitbucket/README.md
+++ b/packages/bitbucket/README.md
@@ -231,7 +231,9 @@ Parameters:
 - `projectKey` (string, required): The project key
 - `repositorySlug` (string, required): The repository slug
 - `path` (string, required): Path to the file in the repository
-- `at` (string, optional): Commit or branch to get the file from (defaults to main/master branch)
+- `at` (string, optional): Branch, tag or commit to read the file at (defaults to the repository's default branch)
+
+Pointing `path` at a directory returns that directory's git tree listing instead of file content.
 
 #### 5. bitbucket_getPullRequests
 

--- a/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
+++ b/packages/bitbucket/src/__tests__/bitbucket-service.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { initializeRuntimeConfig } from '@atlassian-dc-mcp/common';
 import { BitbucketService } from '../bitbucket-service.js';
-import { PullRequestsService } from '../bitbucket-client/index.js';
+import { PullRequestsService, RepositoryService } from '../bitbucket-client/index.js';
 import { request as mockRequest } from '../bitbucket-client/core/request.js';
 
 // Mock the request function
@@ -24,6 +24,9 @@ jest.mock('../bitbucket-client/index.js', () => ({
     getPage: jest.fn(),
     getReviewers: jest.fn(),
     get3: jest.fn()
+  },
+  RepositoryService: {
+    streamRaw: jest.fn()
   },
   OpenAPI: {
     BASE: '',
@@ -1203,6 +1206,78 @@ describe('BitbucketService', () => {
         mockPullRequestId,
         'src/file.txt'
       );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API Error');
+    });
+  });
+
+  describe('getFileContent', () => {
+    const mockFileContent = 'FROM node:20-alpine\n\nWORKDIR /app\n';
+
+    it('should fetch a file at the repository default branch when at is omitted', async () => {
+      (RepositoryService.streamRaw as jest.Mock).mockResolvedValue(mockFileContent);
+
+      const result = await bitbucketService.getFileContent(mockProjectKey, mockRepositorySlug, 'Dockerfile');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe(mockFileContent);
+      expect(RepositoryService.streamRaw).toHaveBeenCalledWith(
+        'Dockerfile',
+        mockProjectKey,
+        mockRepositorySlug,
+        undefined
+      );
+    });
+
+    it('should pass the ref through and keep nested paths intact', async () => {
+      (RepositoryService.streamRaw as jest.Mock).mockResolvedValue(mockFileContent);
+
+      await bitbucketService.getFileContent(
+        mockProjectKey,
+        mockRepositorySlug,
+        'deploy/base/configmap.yaml',
+        'refs/heads/main'
+      );
+
+      expect(RepositoryService.streamRaw).toHaveBeenCalledWith(
+        'deploy/base/configmap.yaml',
+        mockProjectKey,
+        mockRepositorySlug,
+        'refs/heads/main'
+      );
+    });
+
+    it('should strip a leading slash from the path', async () => {
+      (RepositoryService.streamRaw as jest.Mock).mockResolvedValue(mockFileContent);
+
+      await bitbucketService.getFileContent(mockProjectKey, mockRepositorySlug, '/src/index.ts');
+
+      expect(RepositoryService.streamRaw).toHaveBeenCalledWith(
+        'src/index.ts',
+        mockProjectKey,
+        mockRepositorySlug,
+        undefined
+      );
+    });
+
+    it('should normalize project key and repository slug casing', async () => {
+      (RepositoryService.streamRaw as jest.Mock).mockResolvedValue(mockFileContent);
+
+      await bitbucketService.getFileContent('test', 'TEST-REPO', 'Dockerfile');
+
+      expect(RepositoryService.streamRaw).toHaveBeenCalledWith(
+        'Dockerfile',
+        'TEST',
+        'test-repo',
+        undefined
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      (RepositoryService.streamRaw as jest.Mock).mockRejectedValue(new Error('API Error'));
+
+      const result = await bitbucketService.getFileContent(mockProjectKey, mockRepositorySlug, 'missing.txt');
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('API Error');

--- a/packages/bitbucket/src/bitbucket-service.ts
+++ b/packages/bitbucket/src/bitbucket-service.ts
@@ -216,6 +216,25 @@ export class BitbucketService {
   }
 
   /**
+   * Get the raw content of a file in a repository
+   * @param projectKey The project key
+   * @param repositorySlug The repository slug
+   * @param path The path to the file in the repository
+   * @param at Optional branch, tag or commit to read the file at. Defaults to the repository default branch
+   * @returns Promise with the raw file content
+   */
+  async getFileContent(projectKey: string, repositorySlug: string, path: string, at?: string) {
+    projectKey = projectKey.toUpperCase();
+    repositorySlug = repositorySlug.toLowerCase();
+    // Leading slashes would produce a double slash in the URL and a 404 from Bitbucket.
+    const filePath = path.replace(/^\/+/, '');
+    return handleApiOperation(
+      () => RepositoryService.streamRaw(filePath, projectKey, repositorySlug, at),
+      'Error fetching file content'
+    );
+  }
+
+  /**
    * Get pull requests for a repository
    * @param projectKey The project key
    * @param repositorySlug The repository slug
@@ -1021,6 +1040,12 @@ export const bitbucketToolSchemas = {
   getRepository: {
     projectKey: z.string().describe("The project key"),
     repositorySlug: z.string().describe("The repository slug")
+  },
+  getFileContent: {
+    projectKey: z.string().describe("The project key"),
+    repositorySlug: z.string().describe("The repository slug"),
+    path: z.string().describe("Path to the file in the repository (e.g. 'src/index.ts')"),
+    at: z.string().optional().describe("A branch, tag or commit to read the file at (e.g. 'refs/heads/main', 'feature/x', or a commit id). Defaults to the repository's default branch")
   },
   getCommits: {
     projectKey: z.string().describe("The project key"),

--- a/packages/bitbucket/src/index.ts
+++ b/packages/bitbucket/src/index.ts
@@ -69,6 +69,16 @@ server.tool(
 );
 
 server.tool(
+  "bitbucket_getFileContent",
+  "Get the raw content of a file in a Bitbucket repository, at a branch, tag or commit. Use this to read a source file without cloning the repository. 'at' defaults to the repository's default branch. Pointing 'path' at a directory returns that directory's git tree listing instead of file content.",
+  bitbucketToolSchemas.getFileContent,
+  async ({ projectKey, repositorySlug, path, at }) => {
+    const result = await bitbucketService.getFileContent(projectKey, repositorySlug, path, at);
+    return formatToolResponse(result);
+  }
+);
+
+server.tool(
   "bitbucket_getCommits",
   "Get commits for a Bitbucket repository",
   bitbucketToolSchemas.getCommits,


### PR DESCRIPTION
Closes #37

## Summary

`packages/bitbucket/README.md` has documented `bitbucket_getFileContent` under **Available Tools** since early on, and "Get file contents" is listed under **Features** — but the tool was never registered. Anyone reading the README wires it up and gets nothing back.

This implements it exactly as the README already describes it:

| Parameter | Notes |
|---|---|
| `projectKey` (required) | |
| `repositorySlug` (required) | |
| `path` (required) | path to the file, e.g. `deploy/base/configmap.yaml`; a leading `/` is stripped so it cannot produce a double slash |
| `at` (optional) | branch, tag or commit — `refs/heads/main`, `feature/x`, or a commit id. Omitted → the repository's default branch |

Implemented on the already-generated `RepositoryService.streamRaw` (`GET /api/latest/projects/{key}/repos/{slug}/raw/{path}`), wrapped in the usual `handleApiOperation` with the same project-key/repo-slug case normalization as the neighbouring tools. No client regeneration, no new dependency, ~25 lines of service code.

### Why it matters

Without it there is no way for an agent to read a file it is not already looking at in a diff. Reviewing a PR usually means opening the file the change lives in, checking a helper it calls, or reading a config the change depends on — all of which are outside the diff. Today the only answer is "clone the repo", which an MCP client generally cannot do. It is the single most common thing I have wanted from this server that it could not do.

## Testing

`npm run build` green, `npx jest` in `packages/bitbucket` → **147 passed** (142 before this change). 5 new tests: default branch fallback, ref pass-through with a nested path, leading-slash stripping, key/slug casing, error path.

**Verified against a live Bitbucket Data Center 9.x instance** by calling the built `BitbucketService.getFileContent` directly. All 10 scenarios green:

1. top-level file, no `at` → default-branch content
2. `at: 'refs/heads/master'` → identical to (1)
3. `at: 'fun/merge-mcps'` (branch shorthand) → different content, as expected
4. nested path `deploy/base/configmap.yaml`
5. `/deploy/base/configmap.yaml` (leading slash) → identical to (4)
6. lowercase project key / uppercase repo slug → normalized correctly
7. `at` = a full commit id → the file as of that commit
8. `path` pointing at a directory → Bitbucket returns that directory's git tree listing (`040000 tree <sha>\tbase`) rather than 404; documented in the tool description and the README so the behaviour is not a surprise
9. missing file → `success: false`, 404, with Bitbucket's `NoSuchPathException` message in `details`
10. missing repository → `success: false`, 404

## Notes

- Content is returned verbatim, so a very large file is returned in full. If you would rather have paging, the `browse` resource (`RepositoryService.getContent1`) supports server-side line ranges and would fit a follow-up `bitbucket_browseRepository` tool — happy to add it here or separately, whichever you prefer.
- `#### 3 bitbucket_getBranches` in the same README list is also still unimplemented. Left alone to keep this PR to one tool; say the word and I will send that one too.
