### PR TITLE
fix(jira): use standard /api/2/issue/ endpoint instead of Agile-only /agile/1.0/issue/

### DIFF
--- a/packages/jira/src/__tests__/jira-download.test.ts
+++ b/packages/jira/src/__tests__/jira-download.test.ts
@@ -9,7 +9,7 @@ jest.mock('../jira-client/index.js', () => ({
     getAttachment: jest.fn(),
   },
   IssueService: {
-    getIssue: jest.fn(),
+    getIssue1: jest.fn(),
   },
   MyselfService: {},
   SearchService: {},
@@ -58,7 +58,7 @@ describe('JiraService.downloadAttachments', () => {
   });
 
   it('downloads all attachments on an issue', async () => {
-    (IssueService.getIssue as jest.Mock).mockResolvedValue({
+    (IssueService.getIssue1 as jest.Mock).mockResolvedValue({
       fields: {
         attachment: [
           { id: '1', filename: 'a.txt', content: 'https://test-host/a' },
@@ -70,13 +70,13 @@ describe('JiraService.downloadAttachments', () => {
 
     const result = await service.downloadAttachments({ issueKey: 'PROJ-1', downloadSide: DISABLED_DOWNLOAD });
 
-    expect(IssueService.getIssue).toHaveBeenCalledWith('PROJ-1', undefined, ['attachment']);
+    expect(IssueService.getIssue1).toHaveBeenCalledWith('PROJ-1', undefined, 'attachment');
     expect(result.success).toBe(true);
     expect(result.data!.count).toBe(2);
   });
 
   it('filters issue attachments by filename', async () => {
-    (IssueService.getIssue as jest.Mock).mockResolvedValue({
+    (IssueService.getIssue1 as jest.Mock).mockResolvedValue({
       fields: {
         attachment: [
           { id: '1', filename: 'a.txt', content: 'https://test-host/a' },
@@ -101,7 +101,7 @@ describe('JiraService.downloadAttachments', () => {
   });
 
   it('fails when an issue has no matching attachment', async () => {
-    (IssueService.getIssue as jest.Mock).mockResolvedValue({ fields: { attachment: [] } });
+    (IssueService.getIssue1 as jest.Mock).mockResolvedValue({ fields: { attachment: [] } });
 
     const result = await service.downloadAttachments({ issueKey: 'PROJ-1', filename: 'x.txt', downloadSide: DISABLED_DOWNLOAD });
 

--- a/packages/jira/src/__tests__/jira-service.test.ts
+++ b/packages/jira/src/__tests__/jira-service.test.ts
@@ -14,7 +14,7 @@ jest.mock('../jira-client/index.js', () => ({
   IssueService: {
     getTransitions: jest.fn(),
     doTransition: jest.fn(),
-    getIssue: jest.fn(),
+    getIssue1: jest.fn(),
     editIssue: jest.fn(),
     createIssue: jest.fn(),
     getComments: jest.fn(),
@@ -149,33 +149,25 @@ describe('JiraService', () => {
 
     it('uses the richer default field profile for single issue reads', async () => {
       const mockIssue = { key: mockIssueKey };
-      (IssueService.getIssue as jest.Mock).mockResolvedValue(mockIssue);
+      (IssueService.getIssue1 as jest.Mock).mockResolvedValue(mockIssue);
 
       const result = await jiraService.getIssue(mockIssueKey);
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(mockIssue);
-      expect(IssueService.getIssue).toHaveBeenCalledWith(mockIssueKey, undefined, [
-        'summary',
-        'description',
-        'status',
-        'assignee',
-        'reporter',
-        'priority',
-        'issuetype',
-        'labels',
-        'updated',
-        'parent',
-        'subtasks',
-      ]);
+      expect(IssueService.getIssue1).toHaveBeenCalledWith(
+        mockIssueKey,
+        undefined,
+        'summary,description,status,assignee,reporter,priority,issuetype,labels,updated,parent,subtasks',
+      );
     });
 
     it('honors explicit issue fields', async () => {
-      (IssueService.getIssue as jest.Mock).mockResolvedValue({ key: mockIssueKey });
+      (IssueService.getIssue1 as jest.Mock).mockResolvedValue({ key: mockIssueKey });
 
       await jiraService.getIssue(mockIssueKey, 'renderedFields', ['summary', 'status']);
 
-      expect(IssueService.getIssue).toHaveBeenCalledWith(mockIssueKey, 'renderedFields', ['summary', 'status']);
+      expect(IssueService.getIssue1).toHaveBeenCalledWith(mockIssueKey, 'renderedFields', 'summary,status');
     });
 
     it('uses the package default page size for issue comments', async () => {
@@ -223,14 +215,14 @@ describe('JiraService', () => {
   describe('getIssueDevelopmentInfo', () => {
     it('resolves the numeric issue id then requests pull requests by default', async () => {
       const mockDevInfo = { detail: [{ pullRequests: [] }] };
-      (IssueService.getIssue as jest.Mock).mockResolvedValue({ id: '1314681', key: mockIssueKey });
+      (IssueService.getIssue1 as jest.Mock).mockResolvedValue({ id: '1314681', key: mockIssueKey });
       (__request as jest.Mock).mockResolvedValue(mockDevInfo);
 
       const result = await jiraService.getIssueDevelopmentInfo(mockIssueKey);
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(mockDevInfo);
-      expect(IssueService.getIssue).toHaveBeenCalledWith(mockIssueKey, undefined, ['id']);
+      expect(IssueService.getIssue1).toHaveBeenCalledWith(mockIssueKey, undefined, 'id');
       expect(__request).toHaveBeenCalledWith(OpenAPI, {
         method: 'GET',
         url: '/dev-status/1.0/issue/detail',
@@ -239,7 +231,7 @@ describe('JiraService', () => {
     });
 
     it('honors explicit dataType and applicationType', async () => {
-      (IssueService.getIssue as jest.Mock).mockResolvedValue({ id: '42' });
+      (IssueService.getIssue1 as jest.Mock).mockResolvedValue({ id: '42' });
       (__request as jest.Mock).mockResolvedValue({});
 
       await jiraService.getIssueDevelopmentInfo(mockIssueKey, 'repository', 'github');
@@ -252,7 +244,7 @@ describe('JiraService', () => {
     });
 
     it('fails without calling dev-status when the numeric id is missing', async () => {
-      (IssueService.getIssue as jest.Mock).mockResolvedValue({ key: mockIssueKey });
+      (IssueService.getIssue1 as jest.Mock).mockResolvedValue({ key: mockIssueKey });
 
       const result = await jiraService.getIssueDevelopmentInfo(mockIssueKey);
 
@@ -262,7 +254,7 @@ describe('JiraService', () => {
     });
 
     it('surfaces dev-status request errors', async () => {
-      (IssueService.getIssue as jest.Mock).mockResolvedValue({ id: '1314681' });
+      (IssueService.getIssue1 as jest.Mock).mockResolvedValue({ id: '1314681' });
       (__request as jest.Mock).mockRejectedValue(new Error('View Development Tools permission required'));
 
       const result = await jiraService.getIssueDevelopmentInfo(mockIssueKey);

--- a/packages/jira/src/jira-service.ts
+++ b/packages/jira/src/jira-service.ts
@@ -74,7 +74,7 @@ export class JiraService {
 
   async getIssue(issueKey: string, expand?: string, fields?: string[]) {
     return handleApiOperation(
-      () => IssueService.getIssue(issueKey, expand, toIssueFieldSelection(fields ?? DEFAULT_ISSUE_FIELDS)),
+      () => IssueService.getIssue1(issueKey, expand, (fields ?? DEFAULT_ISSUE_FIELDS).join(',')),
       'Error getting issue'
     );
   }
@@ -171,7 +171,7 @@ export class JiraService {
 
   private async resolveIssueId(issueKey: string): Promise<string> {
     // The dev-status API is keyed by the numeric issue id, not the issue key.
-    const issue = await IssueService.getIssue(issueKey, undefined, toIssueFieldSelection(['id']));
+    const issue = await IssueService.getIssue1(issueKey, undefined, 'id');
     if (!issue?.id) {
       throw new Error(`Could not resolve numeric id for issue ${issueKey}`);
     }
@@ -283,7 +283,7 @@ export class JiraService {
     if (!params.issueKey) {
       throw new Error('Either attachmentId or issueKey must be provided');
     }
-    const issue = await IssueService.getIssue(params.issueKey, undefined, toIssueFieldSelection(['attachment']));
+    const issue = await IssueService.getIssue1(params.issueKey, undefined, 'attachment');
     const all = (((issue as any)?.fields?.attachment) ?? []) as Array<Record<string, any>>;
     const filtered = params.filename ? all.filter((a) => a?.filename === params.filename) : all;
     if (filtered.length === 0) {


### PR DESCRIPTION
## Summary

Replace `IssueService.getIssue()` (Agile API: `/agile/1.0/issue/`) with `IssueService.getIssue1()` (standard API: `/api/2/issue/`) in three places within `jira-service.ts`.

## Problem

`getIssue` uses the Jira **Agile REST API** endpoint which is not available on Jira Service Management (JSM) Data Center instances. The endpoint returns an HTML login page instead of JSON, even though the token is valid and other API calls (`searchIssues`, `createIssue`, etc.) work fine on the same instance.

See #79 for full details.

## Changes

In `packages/jira/src/jira-service.ts`:
- `getIssue()` → `IssueService.getIssue1()` with fields joined as comma-separated string
- `resolveIssueId()` → same change (used by `getIssueDevelopmentInfo`)
- `resolveAttachmentBeans()` → same change (used by `downloadAttachments`)

## Trade-off

Agile-specific fields (`sprint`, `closedSprints`, `flagged`, `epic`) are no longer included in the `getIssue` response. These are:
- Irrelevant for JSM/Core instances
- Rarely needed for basic issue retrieval on Software instances
- Still accessible via `searchIssues` with explicit field requests if needed

## Testing

- ✅ Jira Software DC — `getIssue` returns JSON via `/api/2/issue/`
- ✅ Jira Service Management DC 10.3.22 — `getIssue` now works (previously returned HTML login page)
- ✅ `searchIssues`, `createIssue`, `updateIssue`, `transitionIssue` — unaffected

Fixes #79